### PR TITLE
feat(macos): add team_id option for apple notarization

### DIFF
--- a/.changes/mac-notarytool-team-id.md
+++ b/.changes/mac-notarytool-team-id.md
@@ -1,0 +1,5 @@
+---
+"cargo-packager": minor
+---
+
+Read the `APPLE_TEAM_ID` environment variable for macOS notarization arguments.

--- a/crates/packager/src/codesign/macos.rs
+++ b/crates/packager/src/codesign/macos.rs
@@ -338,13 +338,14 @@ fn staple_app(app_bundle_path: PathBuf) -> crate::Result<()> {
 #[derive(Debug)]
 pub enum NotarizeAuth {
     AppleId {
-        apple_id: String,
-        password: String,
+        apple_id: OsString,
+        password: OsString,
+        team_id: Option<OsString>,
     },
     ApiKey {
-        key: String,
+        key: OsString,
         key_path: PathBuf,
-        issuer: String,
+        issuer: OsString,
     },
 }
 
@@ -355,11 +356,20 @@ pub trait NotarytoolCmdExt {
 impl NotarytoolCmdExt for Command {
     fn notarytool_args(&mut self, auth: &NotarizeAuth) -> &mut Self {
         match auth {
-            NotarizeAuth::AppleId { apple_id, password } => self
-                .arg("--apple-id")
-                .arg(apple_id)
-                .arg("--password")
-                .arg(password),
+            NotarizeAuth::AppleId {
+                apple_id,
+                password,
+                team_id,
+            } => {
+                self.arg("--username")
+                    .arg(apple_id)
+                    .arg("--password")
+                    .arg(password);
+                if let Some(team_id) = team_id {
+                    self.arg("--team-id").arg(team_id);
+                }
+                self
+            }
             NotarizeAuth::ApiKey {
                 key,
                 key_path,
@@ -380,50 +390,28 @@ pub fn notarize_auth() -> crate::Result<NotarizeAuth> {
     match (
         std::env::var_os("APPLE_ID"),
         std::env::var_os("APPLE_PASSWORD"),
+        std::env::var_os("APPLE_TEAM_ID"),
     ) {
-        (Some(apple_id), Some(apple_password)) => {
-            let apple_id = apple_id
-                .to_str()
-                .expect("failed to convert APPLE_ID to string")
-                .to_string();
-            let password = apple_password
-                .to_str()
-                .expect("failed to convert APPLE_PASSWORD to string")
-                .to_string();
-            Ok(NotarizeAuth::AppleId { apple_id, password })
-        }
+        (Some(apple_id), Some(password), team_id) => Ok(NotarizeAuth::AppleId {
+            apple_id,
+            password,
+            team_id,
+        }),
         _ => {
             match (
                 std::env::var_os("APPLE_API_KEY"),
                 std::env::var_os("APPLE_API_ISSUER"),
                 std::env::var("APPLE_API_KEY_PATH"),
             ) {
-                (Some(api_key), Some(api_issuer), Ok(key_path)) => {
-                    let key = api_key
-                        .to_str()
-                        .expect("failed to convert APPLE_API_KEY to string")
-                        .to_string();
-                    let issuer = api_issuer
-                        .to_str()
-                        .expect("failed to convert APPLE_API_ISSUER to string")
-                        .to_string();
-                    Ok(NotarizeAuth::ApiKey {
-                        key,
-                        key_path: key_path.into(),
-                        issuer,
-                    })
-                }
-                (Some(api_key), Some(api_issuer), Err(_)) => {
-                    let key = api_key
-                        .to_str()
-                        .expect("failed to convert APPLE_API_KEY to string")
-                        .to_string();
-                    let issuer = api_issuer
-                        .to_str()
-                        .expect("failed to convert APPLE_API_ISSUER to string")
-                        .to_string();
-
-                    let api_key_file_name = format!("AuthKey_{key}.p8");
+                (Some(key), Some(issuer), Ok(key_path)) => Ok(NotarizeAuth::ApiKey {
+                    key,
+                    key_path: key_path.into(),
+                    issuer,
+                }),
+                (Some(key), Some(issuer), Err(_)) => {
+                    let mut api_key_file_name = OsString::from("AuthKey_");
+                    api_key_file_name.push(&key);
+                    api_key_file_name.push(".p8");
                     let mut key_path = None;
 
                     let mut search_paths = vec!["./private_keys".into()];
@@ -448,7 +436,9 @@ pub fn notarize_auth() -> crate::Result<NotarizeAuth> {
                         })
                     } else {
                         Err(Error::ApiKeyMissing {
-                            filename: api_key_file_name,
+                            filename: api_key_file_name
+                                .into_string()
+                                .expect("failed to convert api_key_file_name to string"),
                         })
                     }
                 }
@@ -458,7 +448,7 @@ pub fn notarize_auth() -> crate::Result<NotarizeAuth> {
     }
 }
 
-fn find_api_key(folder: PathBuf, file_name: &str) -> Option<PathBuf> {
+fn find_api_key(folder: PathBuf, file_name: &OsString) -> Option<PathBuf> {
     let path = folder.join(file_name);
     if path.exists() {
         Some(path)

--- a/crates/packager/src/codesign/macos.rs
+++ b/crates/packager/src/codesign/macos.rs
@@ -361,7 +361,7 @@ impl NotarytoolCmdExt for Command {
                 password,
                 team_id,
             } => {
-                self.arg("--username")
+                self.arg("--apple-id")
                     .arg(apple_id)
                     .arg("--password")
                     .arg(password);

--- a/crates/packager/src/codesign/macos.rs
+++ b/crates/packager/src/codesign/macos.rs
@@ -340,7 +340,7 @@ pub enum NotarizeAuth {
     AppleId {
         apple_id: OsString,
         password: OsString,
-        team_id: Option<OsString>,
+        team_id: OsString,
     },
     ApiKey {
         key: OsString,
@@ -364,10 +364,10 @@ impl NotarytoolCmdExt for Command {
                 self.arg("--apple-id")
                     .arg(apple_id)
                     .arg("--password")
-                    .arg(password);
-                if let Some(team_id) = team_id {
-                    self.arg("--team-id").arg(team_id);
-                }
+                    .arg(password)
+                    .arg("--team-id")
+                    .arg(team_id);
+
                 self
             }
             NotarizeAuth::ApiKey {
@@ -392,11 +392,12 @@ pub fn notarize_auth() -> crate::Result<NotarizeAuth> {
         std::env::var_os("APPLE_PASSWORD"),
         std::env::var_os("APPLE_TEAM_ID"),
     ) {
-        (Some(apple_id), Some(password), team_id) => Ok(NotarizeAuth::AppleId {
+        (Some(apple_id), Some(password), Some(team_id)) => Ok(NotarizeAuth::AppleId {
             apple_id,
             password,
             team_id,
         }),
+        (Some(_apple_id), Some(_password), None) => Err(Error::MissingNotarizeAuthTeamId),
         _ => {
             match (
                 std::env::var_os("APPLE_API_KEY"),

--- a/crates/packager/src/error.rs
+++ b/crates/packager/src/error.rs
@@ -170,8 +170,13 @@ pub enum Error {
         filename: String,
     },
     /// Missing notarize environment variables.
-    #[error("Could not find APPLE_ID & APPLE_PASSWORD or APPLE_API_KEY & APPLE_API_ISSUER & APPLE_API_KEY_PATH environment variables found")]
+    #[error("Could not find APPLE_ID & APPLE_PASSWORD & APPLE_TEAM_ID or APPLE_API_KEY & APPLE_API_ISSUER & APPLE_API_KEY_PATH environment variables found")]
     MissingNotarizeAuthVars,
+    /// Missing norarize APPLE_TEAM_ID environment variable.
+    #[error(
+        "The team ID is now required for notarization with app-specific password as authentication. Please set the `APPLE_TEAM_ID` environment variable. You can find the team ID in https://developer.apple.com/account#MembershipDetailsCard."
+      )]
+    MissingNotarizeAuthTeamId,
     /// Failed to list keychains
     #[error("Failed to list keychains: {0}")]
     FailedToListKeyChain(std::io::Error),


### PR DESCRIPTION
Port of https://github.com/tauri-apps/tauri/pull/7775
Port of https://github.com/tauri-apps/tauri/pull/7934
Port of https://github.com/tauri-apps/tauri/pull/7972

Made some changes to the origin PR's error handling since we have refactored them to the `enum Error`

Tested the notarization process on my Macbook. But it would be nice if someone could double-check it again 👀 