### PR TITLE
fix(app): error of path not found in copy_dir

### DIFF
--- a/.changes/fix-path-not-exist-error.md
+++ b/.changes/fix-path-not-exist-error.md
@@ -1,0 +1,5 @@
+---
+"cargo-packager": patch
+---
+
+Fixed an error message that the source path does not exist when packaging .app

--- a/crates/packager/src/package/app/mod.rs
+++ b/crates/packager/src/package/app/mod.rs
@@ -208,7 +208,7 @@ fn create_info_plist(
 #[tracing::instrument(level = "trace")]
 fn copy_dir(from: &Path, to: &Path) -> crate::Result<()> {
     if !from.exists() {
-        return Err(crate::Error::AlreadyExists(from.to_path_buf()));
+        return Err(crate::Error::DoesNotExist(from.to_path_buf()));
     }
     if !from.is_dir() {
         return Err(crate::Error::IsNotDirectory(from.to_path_buf()));


### PR DESCRIPTION
This happens when bundling frameworks to `.app`, and frameworks does not exist with the provided path.


#### Reproduce
Add the following to `Cargo.toml` and run the packager to bundle `.app`,
```
[package.metadata.packager.macos]
frameworks = ["./somewhere/not/exist"]
```