### PR TITLE
Add glob support for icons field

### DIFF
--- a/.changes/glob-icons.md
+++ b/.changes/glob-icons.md
@@ -1,0 +1,5 @@
+---
+"cargo-packager": "patch"
+---
+
+Add glob patterns support for the icons option in config.

--- a/crates/packager/schema.json
+++ b/crates/packager/schema.json
@@ -169,7 +169,7 @@
       ]
     },
     "icons": {
-      "description": "The app's icon list.",
+      "description": "The app's icon list. Supports glob patterns.",
       "type": [
         "array",
         "null"

--- a/crates/packager/src/config/builder.rs
+++ b/crates/packager/src/config/builder.rs
@@ -134,7 +134,7 @@ impl ConfigBuilder {
     pub fn icons<I, P>(mut self, icons: I) -> Self
     where
         I: IntoIterator<Item = P>,
-        P: Into<PathBuf>,
+        P: Into<String>,
     {
         self.0
             .icons

--- a/crates/packager/src/config/builder.rs
+++ b/crates/packager/src/config/builder.rs
@@ -131,10 +131,10 @@ impl ConfigBuilder {
     }
 
     /// Sets [`Config::icons`].
-    pub fn icons<I, P>(mut self, icons: I) -> Self
+    pub fn icons<I, S>(mut self, icons: I) -> Self
     where
-        I: IntoIterator<Item = P>,
-        P: Into<String>,
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
     {
         self.0
             .icons

--- a/crates/packager/src/config/mod.rs
+++ b/crates/packager/src/config/mod.rs
@@ -1488,7 +1488,7 @@ pub struct Config {
     pub copyright: Option<String>,
     /// The app's category.
     pub category: Option<AppCategory>,
-    /// The app's icon list. Support glob.
+    /// The app's icon list. Supports glob patterns.
     pub icons: Option<Vec<String>>,
     /// The file associations
     #[serde(alias = "file-associations", alias = "file_associations")]
@@ -1656,7 +1656,6 @@ impl Config {
 
     /// Returns all icons path.
     pub fn icons(&self) -> crate::Result<Option<Vec<PathBuf>>> {
-        
         let Some(patterns) = &self.icons else {
             return Ok(None);
         };
@@ -1664,24 +1663,11 @@ impl Config {
         let mut paths = Vec::new();
 
         for pattern in patterns {
-            match glob::glob(&pattern) {
-                Ok(icon_paths) => {
-                    for icon_path in icon_paths {
-                        match icon_path {
-                            Ok(path) => paths.push(path),
-                            Err(_e) => {
-                                //return e.into()
-                                panic!()
-                            },
-                        }
-                    }
-                },
-                Err(_e) =>  {
-                    //return e.into()
-                    panic!()
-                },
+            for icon_path in glob::glob(pattern)? {
+                paths.push(icon_path?);
             }
         }
+
         Ok(Some(paths))
     }
 }

--- a/crates/packager/src/config/mod.rs
+++ b/crates/packager/src/config/mod.rs
@@ -1659,15 +1659,12 @@ impl Config {
         let Some(patterns) = &self.icons else {
             return Ok(None);
         };
-
         let mut paths = Vec::new();
-
         for pattern in patterns {
             for icon_path in glob::glob(pattern)? {
                 paths.push(icon_path?);
             }
         }
-
         Ok(Some(paths))
     }
 }
@@ -1754,8 +1751,8 @@ impl Config {
     }
 
     #[allow(unused)]
-    pub(crate) fn find_ico(&self) -> Option<PathBuf> {
-        self.icons
+    pub(crate) fn find_ico(&self) -> crate::Result<Option<PathBuf>> {
+        let icon = self.icons()?
             .as_ref()
             .and_then(|icons| {
                 icons
@@ -1767,7 +1764,8 @@ impl Config {
                         })
                     })
             })
-            .map(PathBuf::from)
+            .map(PathBuf::from);
+        Ok(icon)
     }
 
     #[allow(unused)]

--- a/crates/packager/src/config/mod.rs
+++ b/crates/packager/src/config/mod.rs
@@ -1488,8 +1488,8 @@ pub struct Config {
     pub copyright: Option<String>,
     /// The app's category.
     pub category: Option<AppCategory>,
-    /// The app's icon list.
-    pub icons: Option<Vec<PathBuf>>,
+    /// The app's icon list. Support glob.
+    pub icons: Option<Vec<String>>,
     /// The file associations
     #[serde(alias = "file-associations", alias = "file_associations")]
     pub file_associations: Option<Vec<FileAssociation>>,
@@ -1652,6 +1652,37 @@ impl Config {
             .find(|bin| bin.main)
             .map(|b| b.path.file_stem().unwrap().to_string_lossy().into_owned())
             .ok_or_else(|| crate::Error::MainBinaryNotFound)
+    }
+
+    /// Returns all icons path.
+    pub fn icons(&self) -> crate::Result<Option<Vec<PathBuf>>> {
+        
+        let Some(patterns) = &self.icons else {
+            return Ok(None);
+        };
+
+        let mut paths = Vec::new();
+
+        for pattern in patterns {
+            match glob::glob(&pattern) {
+                Ok(icon_paths) => {
+                    for icon_path in icon_paths {
+                        match icon_path {
+                            Ok(path) => paths.push(path),
+                            Err(_e) => {
+                                //return e.into()
+                                panic!()
+                            },
+                        }
+                    }
+                },
+                Err(_e) =>  {
+                    //return e.into()
+                    panic!()
+                },
+            }
+        }
+        Ok(Some(paths))
     }
 }
 

--- a/crates/packager/src/config/mod.rs
+++ b/crates/packager/src/config/mod.rs
@@ -1752,7 +1752,8 @@ impl Config {
 
     #[allow(unused)]
     pub(crate) fn find_ico(&self) -> crate::Result<Option<PathBuf>> {
-        let icon = self.icons()?
+        let icon = self
+            .icons()?
             .as_ref()
             .and_then(|icons| {
                 icons

--- a/crates/packager/src/package/deb/mod.rs
+++ b/crates/packager/src/package/deb/mod.rs
@@ -48,9 +48,8 @@ fn generate_icon_files(config: &Config, data_dir: &Path) -> crate::Result<BTreeS
         ))
     };
     let mut icons_set = BTreeSet::new();
-    if let Some(icons) = &config.icons {
+    if let Some(icons) = config.icons()? {
         for icon_path in icons {
-            let icon_path = PathBuf::from(icon_path);
             if icon_path.extension() != Some(OsStr::new("png")) {
                 continue;
             }
@@ -78,7 +77,7 @@ fn generate_icon_files(config: &Config, data_dir: &Path) -> crate::Result<BTreeS
                 std::fs::copy(&icon_path, &deb_icon.path)?;
                 icons_set.insert(deb_icon);
             }
-        }
+        }  
     }
     Ok(icons_set)
 }

--- a/crates/packager/src/package/deb/mod.rs
+++ b/crates/packager/src/package/deb/mod.rs
@@ -77,7 +77,7 @@ fn generate_icon_files(config: &Config, data_dir: &Path) -> crate::Result<BTreeS
                 std::fs::copy(&icon_path, &deb_icon.path)?;
                 icons_set.insert(deb_icon);
             }
-        }  
+        }
     }
     Ok(icons_set)
 }

--- a/crates/packager/src/package/wix/mod.rs
+++ b/crates/packager/src/package/wix/mod.rs
@@ -519,7 +519,7 @@ fn build_wix_app_installer(ctx: &Context, wix_path: &Path) -> crate::Result<Vec<
     data.insert("app_exe_source", to_json(&main_binary_path));
 
     // copy icon from `settings.windows().icon_path` folder to resource folder near msi
-    if let Some(icon) = config.find_ico() {
+    if let Some(icon) = config.find_ico()? {
         let icon_path = dunce::canonicalize(icon)?;
         data.insert("icon_path", to_json(icon_path));
     }

--- a/crates/packager/src/util.rs
+++ b/crates/packager/src/util.rs
@@ -279,16 +279,15 @@ pub(crate) fn is_retina<P: AsRef<Path>>(path: P) -> bool {
 pub fn create_icns_file(out_dir: &Path, config: &crate::Config) -> crate::Result<Option<PathBuf>> {
     use image::GenericImageView;
 
-    if config.icons.as_ref().map(|i| i.len()).unwrap_or_default() == 0 {
+    let icons = config.icons()?;
+    if icons.as_ref().map(|i| i.len()).unwrap_or_default() == 0 {
         return Ok(None);
     }
 
     // If one of the icon files is already an ICNS file, just use that.
-    if let Some(icons) = &config.icons {
+    if let Some(icons) = icons {
         std::fs::create_dir_all(out_dir)?;
-
         for icon_path in icons {
-            let icon_path = PathBuf::from(icon_path);
             if icon_path.extension() == Some(std::ffi::OsStr::new("icns")) {
                 let dest_path = out_dir.join(
                     icon_path
@@ -330,8 +329,8 @@ pub fn create_icns_file(out_dir: &Path, config: &crate::Config) -> crate::Result
     }
 
     let mut images_to_resize: Vec<(image::DynamicImage, u32, u32)> = vec![];
-    if let Some(icons) = &config.icons {
-        for icon_path in icons {
+    if let Some(icons) = config.icons()? {
+        for icon_path in &icons {
             let icon = image::open(icon_path)?;
             let density = if is_retina(icon_path) { 2 } else { 1 };
             let (w, h) = icon.dimensions();


### PR DESCRIPTION
This works for deb. Using the helpers method, it should be easy to port this to other target. But i don't have a mac for testing, and i should be able to get a Windows in a few weeks.

I know this code is a little shitty, i'm sorry. I never used `thiserror` crate before, so maybe it can be written with less lines.
Also, i was not able to convert a glob error to the error of this crate. Maybe i missing something here. And somehow, rust-anlyzer just stop working on this project, so a little painful to debug this.