### PR TITLE
Fix Debian package launching issue

### DIFF
--- a/.changes/fix-deb-launching.md
+++ b/.changes/fix-deb-launching.md
@@ -1,0 +1,5 @@
+---
+"cargo-packager": patch
+---
+
+Fix Debian packages launching issues due to previous patch

--- a/.changes/fix-deb-launching.md
+++ b/.changes/fix-deb-launching.md
@@ -2,4 +2,4 @@
 "cargo-packager": patch
 ---
 
-Fix Debian packages launching issues due to previous patch
+Fix Debian packages launching issues due to incorrect permissions

--- a/crates/packager/src/package/deb/mod.rs
+++ b/crates/packager/src/package/deb/mod.rs
@@ -419,19 +419,19 @@ fn create_tar_from_dir<P: AsRef<Path>, W: Write>(src_dir: P, dest_file: W) -> cr
         if entry.file_type().is_dir() {
             let stat = std::fs::metadata(src_path)?;
             let mut header = tar::Header::new_gnu();
+            header.set_mode(0o755);
             header.set_metadata(&stat);
             header.set_uid(0);
             header.set_gid(0);
-            header.set_mode(0o755);
             tar_builder.append_data(&mut header, dest_path, &mut std::io::empty())?;
         } else {
             let mut src_file = std::fs::File::open(src_path)?;
             let stat = src_file.metadata()?;
             let mut header = tar::Header::new_gnu();
+            header.set_mode(0o644);
             header.set_metadata(&stat);
             header.set_uid(0);
             header.set_gid(0);
-            header.set_mode(0o644);
             tar_builder.append_data(&mut header, dest_path, &mut src_file)?;
         }
     }


### PR DESCRIPTION
This commit fixes #119 , which was caused due to previous patch, #118 

For some weird reason, order of `set_mode` matters a lot here. Even if we use `set_mode` just after `set_metadata`, there was same error.

Anyways, it should be fixed now.

Thank You!