### PR TITLE
feat(deb): add `priority` and `section` options

### DIFF
--- a/.changes/priority-and-section.md
+++ b/.changes/priority-and-section.md
@@ -1,0 +1,5 @@
+---
+"cargo-packager": minor
+---
+
+Add the support for priority and section in Debian Config

--- a/.changes/priority-and-section.md
+++ b/.changes/priority-and-section.md
@@ -2,4 +2,4 @@
 "cargo-packager": minor
 ---
 
-Add the support for priority and section in Debian Config
+Add `priority` and `section` options in Debian config

--- a/.changes/priority-and-section.md
+++ b/.changes/priority-and-section.md
@@ -1,5 +1,6 @@
 ---
-"cargo-packager": minor
+"cargo-packager": patch
+"@crabnebula/packager": patch
 ---
 
 Add `priority` and `section` options in Debian config

--- a/bindings/packager/nodejs/schema.json
+++ b/bindings/packager/nodejs/schema.json
@@ -722,6 +722,20 @@
             "null"
           ]
         },
+        "section": {
+          "description": "Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "priority": {
+          "description": "Change the priority of the Debian Package. By default, it is set to optional. Recognized Priorities as of now are :  required, important, standard, optional, extra",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "files": {
           "description": "List of custom files to add to the deb package. Maps a dir/file to a dir/file inside the debian package.",
           "type": [

--- a/bindings/packager/nodejs/schema.json
+++ b/bindings/packager/nodejs/schema.json
@@ -730,7 +730,7 @@
           ]
         },
         "priority": {
-          "description": "Change the priority of the Debian Package. By default, it is set to optional. Recognized Priorities as of now are :  required, important, standard, optional, extra",
+          "description": "Change the priority of the Debian Package. By default, it is set to `optional`. Recognized Priorities as of now are :  `required`, `important`, `standard`, `optional`, `extra`",
           "type": [
             "string",
             "null"

--- a/bindings/packager/nodejs/src-ts/config.d.ts
+++ b/bindings/packager/nodejs/src-ts/config.d.ts
@@ -407,6 +407,21 @@ export interface DebianConfig {
    * Default file contents: ```text [Desktop Entry] Categories={{categories}} {{#if comment}} Comment={{comment}} {{/if}} Exec={{exec}} Icon={{icon}} Name={{name}} Terminal=false Type=Application {{#if mime_type}} MimeType={{mime_type}} {{/if}} ```
    */
   desktopTemplate?: string | null;
+
+  /**
+   * Define the section in Debian Control file. It is recommended to add a section in the debian application.
+   * 
+   * See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections
+   */
+  section?: string | null;
+
+  /**
+   * Change the priority of the Debian Package. By default, it is set to optional. 
+   * 
+   * See : https://www.debian.org/doc/debian-policy/ch-archive.html#priorities
+   */
+  priority?: string | null;
+
   /**
    * List of custom files to add to the deb package. Maps a dir/file to a dir/file inside the debian package.
    */

--- a/bindings/packager/nodejs/src-ts/config.d.ts
+++ b/bindings/packager/nodejs/src-ts/config.d.ts
@@ -407,21 +407,14 @@ export interface DebianConfig {
    * Default file contents: ```text [Desktop Entry] Categories={{categories}} {{#if comment}} Comment={{comment}} {{/if}} Exec={{exec}} Icon={{icon}} Name={{name}} Terminal=false Type=Application {{#if mime_type}} MimeType={{mime_type}} {{/if}} ```
    */
   desktopTemplate?: string | null;
-
   /**
-   * Define the section in Debian Control file. It is recommended to add a section in the debian application.
-   * 
-   * See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections
+   * Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections
    */
   section?: string | null;
-
   /**
-   * Change the priority of the Debian Package. By default, it is set to optional. 
-   * 
-   * See : https://www.debian.org/doc/debian-policy/ch-archive.html#priorities
+   * Change the priority of the Debian Package. By default, it is set to optional. Recognized Priorities as of now are :  required, important, standard, optional, extra
    */
   priority?: string | null;
-
   /**
    * List of custom files to add to the deb package. Maps a dir/file to a dir/file inside the debian package.
    */

--- a/bindings/packager/nodejs/src-ts/config.d.ts
+++ b/bindings/packager/nodejs/src-ts/config.d.ts
@@ -412,7 +412,7 @@ export interface DebianConfig {
    */
   section?: string | null;
   /**
-   * Change the priority of the Debian Package. By default, it is set to optional. Recognized Priorities as of now are :  required, important, standard, optional, extra
+   * Change the priority of the Debian Package. By default, it is set to `optional`. Recognized Priorities as of now are :  `required`, `important`, `standard`, `optional`, extra
    */
   priority?: string | null;
   /**

--- a/crates/packager/schema.json
+++ b/crates/packager/schema.json
@@ -722,6 +722,20 @@
             "null"
           ]
         },
+        "section": {
+          "description": "Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "priority": {
+          "description": "Change the priority of the Debian Package. By default, it is set to optional. Recognized Priorities as of now are :  required, important, standard, optional, extra",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "files": {
           "description": "List of custom files to add to the deb package. Maps a dir/file to a dir/file inside the debian package.",
           "type": [

--- a/crates/packager/schema.json
+++ b/crates/packager/schema.json
@@ -730,7 +730,7 @@
           ]
         },
         "priority": {
-          "description": "Change the priority of the Debian Package. By default, it is set to optional. Recognized Priorities as of now are :  required, important, standard, optional, extra",
+          "description": "Change the priority of the Debian Package. By default, it is set to `optional`. Recognized Priorities as of now are :  `required`, `important`, `standard`, `optional`, `extra`",
           "type": [
             "string",
             "null"

--- a/crates/packager/src/config/mod.rs
+++ b/crates/packager/src/config/mod.rs
@@ -313,8 +313,8 @@ pub struct DebianConfig {
     pub desktop_template: Option<PathBuf>,
     /// Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections
     pub section: Option<String>,
-    /// Change the priority of the Debian Package. By default, it is set to optional.
-    /// Recognized Priorities as of now are :  required, important, standard, optional, extra
+    /// Change the priority of the Debian Package. By default, it is set to `optional`.
+    /// Recognized Priorities as of now are :  `required`, `important`, `standard`, `optional`, `extra`
     pub priority: Option<String>,
     /// List of custom files to add to the deb package.
     /// Maps a dir/file to a dir/file inside the debian package.
@@ -360,6 +360,19 @@ impl DebianConfig {
     /// ```
     pub fn desktop_template<P: Into<PathBuf>>(mut self, desktop_template: P) -> Self {
         self.desktop_template.replace(desktop_template.into());
+        self
+    }
+
+    /// Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections
+    pub fn section<S: Into<String>>(self, section: S) -> Self {
+        self.section.replace(section.into());
+        self
+    }
+
+    /// Change the priority of the Debian Package. By default, it is set to `optional`.
+    /// Recognized Priorities as of now are :  `required`, `important`, `standard`, `optional`, `extra`
+    pub fn priority<S: Into<String>>(self, priority: S) -> Self {
+        self.priority.replace(priority.into());
         self
     }
 

--- a/crates/packager/src/config/mod.rs
+++ b/crates/packager/src/config/mod.rs
@@ -311,6 +311,11 @@ pub struct DebianConfig {
     /// ```
     #[serde(alias = "desktop-template", alias = "desktop_template")]
     pub desktop_template: Option<PathBuf>,
+    /// Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections
+    pub section: Option<String>,
+    /// Change the priority of the Debian Package. By default, it is set to optional.
+    /// Recognized Priorities as of now are :  required, important, standard, optional, extra
+    pub priority: Option<String>,
     /// List of custom files to add to the deb package.
     /// Maps a dir/file to a dir/file inside the debian package.
     pub files: Option<HashMap<String, String>>,

--- a/crates/packager/src/config/mod.rs
+++ b/crates/packager/src/config/mod.rs
@@ -364,14 +364,14 @@ impl DebianConfig {
     }
 
     /// Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections
-    pub fn section<S: Into<String>>(self, section: S) -> Self {
+    pub fn section<S: Into<String>>(mut self, section: S) -> Self {
         self.section.replace(section.into());
         self
     }
 
     /// Change the priority of the Debian Package. By default, it is set to `optional`.
     /// Recognized Priorities as of now are :  `required`, `important`, `standard`, `optional`, `extra`
-    pub fn priority<S: Into<String>>(self, priority: S) -> Self {
+    pub fn priority<S: Into<String>>(mut self, priority: S) -> Self {
         self.priority.replace(priority.into());
         self
     }

--- a/crates/packager/src/package/deb/mod.rs
+++ b/crates/packager/src/package/deb/mod.rs
@@ -252,6 +252,16 @@ fn generate_control_file(
     if let Some(authors) = &config.authors {
         writeln!(file, "Maintainer: {}", authors.join(", "))?;
     }
+    if let Some(section) = config.deb().and_then(|d| d.section.as_ref()) {
+        writeln!(file, "Section: {}", section)?;
+    }
+
+    if let Some(priority) = config.deb().and_then(|d| d.priority.as_ref()) {
+        writeln!(file, "Priority: {}", priority)?;
+    }else{
+        writeln!(file, "Priority: optional")?;
+    }
+
     if let Some(homepage) = &config.homepage {
         writeln!(file, "Homepage: {}", homepage)?;
     }
@@ -282,7 +292,7 @@ fn generate_control_file(
             writeln!(file, " {}", line)?;
         }
     }
-    writeln!(file, "Priority: optional")?;
+
     file.flush()?;
     Ok(())
 }

--- a/crates/packager/src/package/deb/mod.rs
+++ b/crates/packager/src/package/deb/mod.rs
@@ -258,7 +258,7 @@ fn generate_control_file(
 
     if let Some(priority) = config.deb().and_then(|d| d.priority.as_ref()) {
         writeln!(file, "Priority: {}", priority)?;
-    }else{
+    } else {
         writeln!(file, "Priority: optional")?;
     }
 

--- a/crates/packager/src/package/deb/mod.rs
+++ b/crates/packager/src/package/deb/mod.rs
@@ -9,8 +9,8 @@ use std::{
     ffi::OsStr,
     fs::File,
     io::Write,
-    path::{Path, PathBuf},
     os::unix::fs::MetadataExt,
+    path::{Path, PathBuf},
 };
 
 use handlebars::Handlebars;
@@ -18,8 +18,8 @@ use heck::AsKebabCase;
 use image::{codecs::png::PngDecoder, ImageDecoder};
 use relative_path::PathExt;
 use serde::Serialize;
-use walkdir::WalkDir;
 use tar::HeaderMode;
+use walkdir::WalkDir;
 
 use super::Context;
 use crate::{

--- a/crates/packager/src/package/deb/mod.rs
+++ b/crates/packager/src/package/deb/mod.rs
@@ -294,7 +294,6 @@ fn generate_control_file(
             writeln!(file, " {}", line)?;
         }
     }
-
     file.flush()?;
     Ok(())
 }
@@ -432,7 +431,6 @@ fn create_tar_from_dir<P: AsRef<Path>, W: Write>(src_dir: P, dest_file: W) -> cr
         let mut header = tar::Header::new_gnu();
         header.set_metadata_in_mode(&stat, HeaderMode::Deterministic);
         header.set_mtime(stat.mtime() as u64);
-
         if entry.file_type().is_dir() {
             tar_builder.append_data(&mut header, dest_path, &mut std::io::empty())?;
         } else {

--- a/examples/tauri/Cargo.toml
+++ b/examples/tauri/Cargo.toml
@@ -44,6 +44,7 @@ icons = [
 
 [package.metadata.packager.deb]
 depends = ["libgtk-3-0", "libwebkit2gtk-4.1-0", "libayatana-appindicator3-1"]
+section = "rust"
 
 [package.metadata.packager.appimage]
 bins = ["/usr/bin/xdg-open"]


### PR DESCRIPTION
I am adding some necessary `config` options for debian packages.

These should be accessible via `[package.metadata.packager.deb]`

These changes are running perfectly fine on Arch Linux as well as Debian, but please, review carefully before approving.

Also, this is not complete yet, I will be adding certain options as well.