### PR TITLE
Add missing Mach-O magic bytes

### DIFF
--- a/.changes/macho-magic-numbers.md
+++ b/.changes/macho-magic-numbers.md
@@ -1,0 +1,6 @@
+---
+"cargo-packager": patch
+"@crabnebula/packager": patch
+---
+
+MacOS code signing did not respect MACH-O header magic bytes 0xBEBAFECA and 0xFEEDFACE

--- a/crates/packager/src/package/app/mod.rs
+++ b/crates/packager/src/package/app/mod.rs
@@ -90,8 +90,15 @@ pub(crate) fn package(ctx: &Context) -> crate::Result<Vec<PathBuf>> {
                 let mut buffer = [0; 4];
                 std::io::Read::read_exact(&mut open_file, &mut buffer)?;
 
-                const MACH_O_MAGIC_NUMBERS: [u32; 5] =
-                    [0xfeedface, 0xfeedfacf, 0xcafebabe, 0xcefaedfe, 0xcffaedfe];
+                const MACH_O_MAGIC_NUMBERS: [u32; 5] = [
+                    0xfeedface, // 32 bit binary little-endian
+                    0xcefaedfe, // 32 bit binary big-endian
+                    0xfeedfacf, // 64 bit binary little-endian
+                    0xcffaedfe, // 64 bit binary big-endian
+                    0xcafebabe, // universal binary
+                    0xfeedfeed, // core dump files
+                    0xfacffeed, // used by electron on x86
+                ];
 
                 let magic = u32::from_be_bytes(buffer);
 


### PR DESCRIPTION
As in https://github.com/crabnebula-dev/cargo-packager/pull/132 introduced, the scanning for Mach-O files to sign was not implemented correctly. It is missing two magic byte combinations which are required for signing core dumps and electron binaries on x86 macos devices. Not sure why, but it seems they have their own magic bytes there