### PR TITLE
feat: add config option to control excluded libs in AppImage

### DIFF
--- a/.changes/excluded-libs-appiamge.md
+++ b/.changes/excluded-libs-appiamge.md
@@ -3,4 +3,4 @@
 "@crabnebula/packager": minor
 ---
 
-Added config feature to control excluded libs in build_appimage.sh
+Added config option to control excluded libs when packaging AppImage

--- a/.changes/excluded-libs-appiamge.md
+++ b/.changes/excluded-libs-appiamge.md
@@ -1,0 +1,6 @@
+---
+"cargo-packager": minor
+"@crabnebula/packager": minor
+---
+
+Added config feature to control excluded libs in build_appimage.sh

--- a/bindings/packager/nodejs/schema.json
+++ b/bindings/packager/nodejs/schema.json
@@ -810,6 +810,16 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "excludedLibs": {
+          "description": "List of globs of libraries to exclude from the final APpImage. For example, to exclude libnss3.so, you'd specify `libnss3*`",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/bindings/packager/nodejs/src-ts/config.d.ts
+++ b/bindings/packager/nodejs/src-ts/config.d.ts
@@ -450,6 +450,10 @@ export interface AppImageConfig {
   linuxdeployPlugins?: {
     [k: string]: string;
   } | null;
+  /**
+   * List of globs of libraries to exclude from the final APpImage. For example, to exclude libnss3.so, you'd specify `libnss3*`
+   */
+  excludedLibs?: string[] | null;
 }
 /**
  * The Linux pacman configuration.

--- a/crates/packager/schema.json
+++ b/crates/packager/schema.json
@@ -810,6 +810,16 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "excludedLibs": {
+          "description": "List of globs of libraries to exclude from the final APpImage. For example, to exclude libnss3.so, you'd specify `libnss3*`",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/crates/packager/src/config/mod.rs
+++ b/crates/packager/src/config/mod.rs
@@ -267,7 +267,7 @@ pub struct AppImageConfig {
     /// you'd specify `gtk` as the key and its url as the value.
     #[serde(alias = "linuxdeploy-plugins", alias = "linuxdeploy_plugins")]
     pub linuxdeploy_plugins: Option<HashMap<String, String>>,
-    /// List of globs of libraries to exclude from the final APpImage.
+    /// List of globs of libraries to exclude from the final AppImage.
     /// For example, to exclude libnss3.so, you'd specify `libnss3*`
     #[serde(alias = "excluded-libraries", alias = "excluded_libraries")]
     pub excluded_libs: Option<Vec<String>>,

--- a/crates/packager/src/config/mod.rs
+++ b/crates/packager/src/config/mod.rs
@@ -267,6 +267,10 @@ pub struct AppImageConfig {
     /// you'd specify `gtk` as the key and its url as the value.
     #[serde(alias = "linuxdeploy-plugins", alias = "linuxdeploy_plugins")]
     pub linuxdeploy_plugins: Option<HashMap<String, String>>,
+    /// List of globs of libraries to exclude from the final APpImage.
+    /// For example, to exclude libnss3.so, you'd specify `libnss3*`
+    #[serde(alias = "excluded-libraries", alias = "excluded_libraries")]
+    pub excluded_libs: Option<Vec<String>>,
 }
 
 impl AppImageConfig {

--- a/crates/packager/src/package/appimage/appimage
+++ b/crates/packager/src/package/appimage/appimage
@@ -41,4 +41,4 @@ cd ..
 # and so appimagelauncher doesn't inject itself and the binary runs directly
 dd if=/dev/zero bs=1 count=3 seek=8 conv=notrunc of="{{packager_tools_path}}/linuxdeploy-{{linuxdeploy_arch}}.AppImage"
 
-OUTPUT="{{appimage_path}}" "{{packager_tools_path}}/linuxdeploy-{{linuxdeploy_arch}}.AppImage" --appimage-extract-and-run --appdir "{{app_name}}.AppDir" {{linuxdeploy_plugins}} --output appimage
+OUTPUT="{{appimage_path}}" "{{packager_tools_path}}/linuxdeploy-{{linuxdeploy_arch}}.AppImage" --appimage-extract-and-run --appdir "{{app_name}}.AppDir" {{linuxdeploy_plugins}} {{excluded_libs}} --output appimage

--- a/crates/packager/src/package/appimage/mod.rs
+++ b/crates/packager/src/package/appimage/mod.rs
@@ -136,6 +136,16 @@ pub(crate) fn package(ctx: &Context) -> crate::Result<Vec<PathBuf>> {
         .join(" ");
     sh_map.insert("linuxdeploy_plugins", to_json(linuxdeploy_plugins));
 
+    let excluded_libraries = config
+        .appimage()
+        .and_then(|a| a.excluded_libs.clone())
+        .unwrap_or_default()
+        .into_iter()
+        .map(|library| format!("--exclude-library {}", library))
+        .collect::<Vec<_>>()
+        .join(" ");
+    sh_map.insert("excluded_libs", to_json(excluded_libraries));
+
     let larger_icon = icons
         .iter()
         .filter(|i| i.width == i.height)


### PR DESCRIPTION
On Arch and maybe other distros it might be relevant to control the automatically included libs. This PR introduces a config option for .appimage files to exclude specific libraries.