### PR TITLE
fix(resource-resolver): Add pacman support for resource resolver, closes #188

### DIFF
--- a/.changes/add-pacman-support-resource-resolver.md
+++ b/.changes/add-pacman-support-resource-resolver.md
@@ -1,5 +1,5 @@
 ---
-"cargo-packager-resource-resolver" : patch
+"cargo-packager-resource-resolver": patch
 ---
 
 Added support for Pacman Packages in the Resource Resolver.

--- a/.changes/add-pacman-support-resource-resolver.md
+++ b/.changes/add-pacman-support-resource-resolver.md
@@ -1,0 +1,5 @@
+---
+"cargo-packager-resource-resolver" : patch
+---
+
+Added support for Pacman Packages in the Resource Resolver.

--- a/crates/resource-resolver/src/lib.rs
+++ b/crates/resource-resolver/src/lib.rs
@@ -64,6 +64,8 @@ pub fn current_format() -> crate::Result<PackageFormat> {
         Ok(PackageFormat::Deb)
     } else if cfg!(CARGO_PACKAGER_FORMAT = "appimage") {
         Ok(PackageFormat::AppImage)
+    } else if cfg!(CARGO_PACKAGER_FORMAT = "pacman") {
+        Ok(PackageFormat::Pacman)
     } else {
         Err(Error::UnkownPackageFormat)
     }
@@ -94,7 +96,7 @@ pub fn resources_dir(package_format: PackageFormat) -> Result<PathBuf> {
                 .ok_or_else(|| Error::ParentNotFound(exe.clone()))?;
             Ok(exe_dir.to_path_buf())
         }
-        PackageFormat::Deb => {
+        PackageFormat::Deb | PackageFormat::Pacman => {
             let exe = current_exe()?;
             let exe_name = exe.file_name().unwrap().to_string_lossy();
 


### PR DESCRIPTION
Add support for Pacman Packages in the Resource Resolver.

- closes #188 

Now, resource resolver can detect `Paman` format and also load resources for it.
