### PR TITLE
feat(packager): always show command output, enhance formatting

### DIFF
--- a/.changes/enhance-shell-output.md
+++ b/.changes/enhance-shell-output.md
@@ -3,4 +3,4 @@
 "@crabnebula/packager": patch
 ---
 
-Show shell commands output (ex: `beforePackageCommand`) if it fails.
+Always show shell commands output for `beforePackageCommand` and `beforeEachPackagingCommand` .

--- a/.changes/enhance-shell-output.md
+++ b/.changes/enhance-shell-output.md
@@ -1,5 +1,6 @@
 ---
 "cargo-packager": patch
+"@crabnebula/packager": patch
 ---
 
-Always show command output and enhance formatting.
+Show shell commands output (ex: `beforePackageCommand`) if it fails.

--- a/.changes/enhance-shell-output.md
+++ b/.changes/enhance-shell-output.md
@@ -1,0 +1,5 @@
+---
+"cargo-packager": patch
+---
+
+Always show command output and enhance formatting.

--- a/crates/packager/src/cli/mod.rs
+++ b/crates/packager/src/cli/mod.rs
@@ -267,6 +267,9 @@ where
 
     if !cli.quite {
         init_tracing_subscriber(cli.verbose);
+        if std::env::var_os("CARGO_TERM_COLOR").is_none() {
+            std::env::set_var("CARGO_TERM_COLOR", "always");
+        }
     }
 
     run_cli(cli)

--- a/crates/packager/src/lib.rs
+++ b/crates/packager/src/lib.rs
@@ -127,13 +127,19 @@ pub fn init_tracing_subscriber(verbosity: u8) {
         .with_file(tracing)
         .with_max_level(level)
         .event_format(TracingFormatter {
-            formatter: tracing_subscriber::fmt::format().compact(),
+            formatter: tracing_subscriber::fmt::format()
+                .compact()
+                .with_target(debug)
+                .with_line_number(tracing)
+                .without_time()
+                .with_file(tracing),
         })
         .init();
 }
 
 struct TracingFormatter {
-    formatter: tracing_subscriber::fmt::format::Format<tracing_subscriber::fmt::format::Compact>,
+    formatter:
+        tracing_subscriber::fmt::format::Format<tracing_subscriber::fmt::format::Compact, ()>,
 }
 
 struct ShellFieldVisitor {

--- a/crates/packager/src/package/mod.rs
+++ b/crates/packager/src/package/mod.rs
@@ -206,7 +206,7 @@ fn run_before_each_packaging_command_hook(
         let output = cmd
             .env("CARGO_PACKAGER_FORMATS", formats_comma_separated)
             .env("CARGO_PACKAGER_FORMAT", format)
-            .output_ok()
+            .output_ok_info()
             .map_err(|e| {
                 crate::Error::HookCommandFailure(
                     "beforeEachPackageCommand".into(),
@@ -249,7 +249,7 @@ fn run_before_packaging_command_hook(
         tracing::info!("Running beforePackageCommand `{script}`");
         let output = cmd
             .env("CARGO_PACKAGER_FORMATS", formats_comma_separated)
-            .output_ok()
+            .output_ok_info()
             .map_err(|e| {
                 crate::Error::HookCommandFailure("beforePackagingCommand".into(), script.into(), e)
             })?;

--- a/crates/packager/src/shell.rs
+++ b/crates/packager/src/shell.rs
@@ -43,7 +43,7 @@ impl CommandExt for Command {
                 if let Ok(0) = stdout.read_until(b'\n', &mut buf) {
                     break;
                 }
-                tracing::info!(
+                tracing::debug!(
                     shell = "stdout",
                     "{}",
                     String::from_utf8_lossy(&buf[..buf.len() - 1])
@@ -63,7 +63,7 @@ impl CommandExt for Command {
                 if let Ok(0) = stderr.read_until(b'\n', &mut buf) {
                     break;
                 }
-                tracing::info!(
+                tracing::error!(
                     shell = "stderr",
                     "{}",
                     String::from_utf8_lossy(&buf[..buf.len() - 1])

--- a/crates/packager/src/shell.rs
+++ b/crates/packager/src/shell.rs
@@ -43,7 +43,11 @@ impl CommandExt for Command {
                 if let Ok(0) = stdout.read_until(b'\n', &mut buf) {
                     break;
                 }
-                tracing::debug!("{}", String::from_utf8_lossy(&buf[..buf.len() - 1]));
+                tracing::info!(
+                    shell = "stdout",
+                    "{}",
+                    String::from_utf8_lossy(&buf[..buf.len() - 1])
+                );
                 lines.extend(&buf);
             }
         });
@@ -59,7 +63,11 @@ impl CommandExt for Command {
                 if let Ok(0) = stderr.read_until(b'\n', &mut buf) {
                     break;
                 }
-                tracing::debug!("{}", String::from_utf8_lossy(&buf[..buf.len() - 1]));
+                tracing::info!(
+                    shell = "stderr",
+                    "{}",
+                    String::from_utf8_lossy(&buf[..buf.len() - 1])
+                );
                 lines.extend(&buf);
             }
         });


### PR DESCRIPTION
It's hard to understand when e.g. a `cargo build` fails because we do not show its output without the `--verbose` flag. This PR changes the tracing event level to INFO so it's always available, and enhances the formatting to remove extra fields, dates, and log level.