### PR TITLE
feat(packager): config for binaries dir

### DIFF
--- a/.changes/binaries-dir.md
+++ b/.changes/binaries-dir.md
@@ -1,0 +1,5 @@
+---
+"cargo-packager": patch
+---
+
+Added `Config::binaries_dir` so you can specify the location of the binaries without modifying the output directory.

--- a/.changes/binaries-dir.md
+++ b/.changes/binaries-dir.md
@@ -2,4 +2,4 @@
 "cargo-packager": patch
 ---
 
-Added `Config::binaries_dir` so you can specify the location of the binaries without modifying the output directory.
+Added `Config::binaries_dir` and `--binaries-dir` so you can specify the location of the binaries without modifying the output directory.

--- a/.changes/out-dir.md
+++ b/.changes/out-dir.md
@@ -1,0 +1,5 @@
+---
+"cargo-packager": minor
+---
+
+Added `--out-dir/-o` flags and removed the positional argument to specify where to ouput packages, use the newly added flags instead.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-packager"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ar",
  "base64 0.21.7",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-packager-resource-resolver"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cargo-packager-utils",
  "heck 0.4.1",

--- a/bindings/packager/nodejs/schema.json
+++ b/bindings/packager/nodejs/schema.json
@@ -93,9 +93,17 @@
       }
     },
     "outDir": {
-      "description": "The directory where the [`Config::binaries`] exist and where the generated packages will be placed.",
+      "description": "The directory where the generated packages will be placed.\n\nIf [`Config::binaries_dir`] is not set, this is also where the [`Config::binaries`] exist.",
       "default": "",
       "type": "string"
+    },
+    "binariesDir": {
+      "description": "The directory where the [`Config::binaries`] exist.\n\nDefaults to [`Config::out_dir`].",
+      "default": null,
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "targetTriple": {
       "description": "The target triple we are packaging for. This mainly affects [`Config::external_binaries`].\n\nDefaults to the current OS target triple.",

--- a/bindings/packager/nodejs/src-ts/config.d.ts
+++ b/bindings/packager/nodejs/src-ts/config.d.ts
@@ -181,9 +181,17 @@ export interface Config {
    */
   formats?: PackageFormat[] | null;
   /**
-   * The directory where the [`Config::binaries`] exist and where the generated packages will be placed.
+   * The directory where the generated packages will be placed.
+   *
+   * If [`Config::binaries_dir`] is not set, this is also where the [`Config::binaries`] exist.
    */
   outDir?: string;
+  /**
+   * The directory where the [`Config::binaries`] exist.
+   *
+   * Defaults to [`Config::out_dir`].
+   */
+  binariesDir?: string | null;
   /**
    * The target triple we are packaging for. This mainly affects [`Config::external_binaries`].
    *

--- a/crates/packager/schema.json
+++ b/crates/packager/schema.json
@@ -93,9 +93,17 @@
       }
     },
     "outDir": {
-      "description": "The directory where the [`Config::binaries`] exist and where the generated packages will be placed.",
+      "description": "The directory where the generated packages will be placed.\n\nIf [`Config::binaries_dir`] is not set, this is also where the [`Config::binaries`] exist.",
       "default": "",
       "type": "string"
+    },
+    "binariesDir": {
+      "description": "The directory where the [`Config::binaries`] exist.\n\nDefaults to [`Config::out_dir`].",
+      "default": null,
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "targetTriple": {
       "description": "The target triple we are packaging for. This mainly affects [`Config::external_binaries`].\n\nDefaults to the current OS target triple.",

--- a/crates/packager/src/cli/config.rs
+++ b/crates/packager/src/cli/config.rs
@@ -138,13 +138,19 @@ pub fn load_configs_from_cargo_workspace(
                     .identifier
                     .replace(format!("com.{}.{}", author, package.name));
             }
-            if config.out_dir.as_os_str().is_empty() {
-                config.out_dir = metadata
-                    .target_directory
-                    .as_std_path()
-                    .to_path_buf()
-                    .join(profile);
+
+            let cargo_out_dir = metadata
+                .target_directory
+                .as_std_path()
+                .to_path_buf()
+                .join(profile);
+            if config.binaries_dir.is_none() {
+                config.binaries_dir.replace(cargo_out_dir.clone());
             }
+            if config.out_dir.as_os_str().is_empty() {
+                config.out_dir = cargo_out_dir;
+            }
+
             if config.description.is_none() {
                 config.description = package.description.clone();
             }

--- a/crates/packager/src/cli/mod.rs
+++ b/crates/packager/src/cli/mod.rs
@@ -60,7 +60,9 @@ pub(crate) struct Cli {
     /// Specify which packages to use from the current workspace.
     #[clap(short, long, value_delimiter = ',')]
     packages: Option<Vec<String>>,
-    /// Specify The directory where the `binaries` exist and where the packages will be placed.
+    /// Specify The directory where the packages will be placed.
+    ///
+    /// If [`Config::binaries_dir`] is not defined, it is also the path where the binaries are located if they use relative paths.
     out_dir: Option<PathBuf>,
 
     /// Package the release version of your app.
@@ -139,7 +141,18 @@ fn run_cli(cli: Cli) -> Result<()> {
         return Ok(());
     }
 
-    let cli_out_dir = cli.out_dir.as_ref().map(dunce::canonicalize).transpose()?;
+    let cli_out_dir = cli
+        .out_dir
+        .as_ref()
+        .map(|p| {
+            if p.exists() {
+                dunce::canonicalize(p)
+            } else {
+                std::fs::create_dir_all(p)?;
+                Ok(p.to_owned())
+            }
+        })
+        .transpose()?;
 
     for (_, config) in &mut configs {
         if let Some(dir) = &cli_out_dir {

--- a/crates/packager/src/cli/mod.rs
+++ b/crates/packager/src/cli/mod.rs
@@ -63,8 +63,13 @@ pub(crate) struct Cli {
     /// Specify The directory where the packages will be placed.
     ///
     /// If [`Config::binaries_dir`] is not defined, it is also the path where the binaries are located if they use relative paths.
+    #[clap(short, long, alias = "out")]
     out_dir: Option<PathBuf>,
-
+    /// Specify The directory where the [`Config::binaries`] exist.
+    ///
+    /// Defaults to [`Config::out_dir`]
+    #[clap(long)]
+    binaries_dir: Option<PathBuf>,
     /// Package the release version of your app.
     /// Ignored when `--config` is used.
     #[clap(short, long, group = "cargo-profile")]

--- a/crates/packager/src/config/mod.rs
+++ b/crates/packager/src/config/mod.rs
@@ -1478,7 +1478,7 @@ pub struct Config {
     /// The directory where the [`Config::binaries`] exist.
     ///
     /// Defaults to [`Config::out_dir`].
-    #[serde(default, alias = "out-dir", alias = "out_dir")]
+    #[serde(default, alias = "binaries-dir", alias = "binaries_dir")]
     pub binaries_dir: Option<PathBuf>,
     /// The target triple we are packaging for. This mainly affects [`Config::external_binaries`].
     ///

--- a/crates/packager/src/config/mod.rs
+++ b/crates/packager/src/config/mod.rs
@@ -1470,9 +1470,16 @@ pub struct Config {
     pub log_level: Option<LogLevel>,
     /// The packaging formats to create, if not present, [`PackageFormat::platform_default`] is used.
     pub formats: Option<Vec<PackageFormat>>,
-    /// The directory where the [`Config::binaries`] exist and where the generated packages will be placed.
+    /// The directory where the generated packages will be placed.
+    ///
+    /// If [`Config::binaries_dir`] is not set, this is also where the [`Config::binaries`] exist.
     #[serde(default, alias = "out-dir", alias = "out_dir")]
     pub out_dir: PathBuf,
+    /// The directory where the [`Config::binaries`] exist.
+    ///
+    /// Defaults to [`Config::out_dir`].
+    #[serde(default, alias = "out-dir", alias = "out_dir")]
+    pub binaries_dir: Option<PathBuf>,
     /// The target triple we are packaging for. This mainly affects [`Config::external_binaries`].
     ///
     /// Defaults to the current OS target triple.
@@ -1624,7 +1631,7 @@ impl Config {
         if binary.path.is_absolute() {
             binary.path.clone()
         } else {
-            self.out_dir().join(&binary.path)
+            self.binaries_dir().join(&binary.path)
         }
     }
 
@@ -1649,8 +1656,20 @@ impl Config {
     pub fn out_dir(&self) -> PathBuf {
         if self.out_dir.as_os_str().is_empty() {
             std::env::current_dir().expect("failed to resolve cwd")
-        } else {
+        } else if self.out_dir.exists() {
             dunce::canonicalize(&self.out_dir).unwrap_or_else(|_| self.out_dir.clone())
+        } else {
+            std::fs::create_dir_all(&self.out_dir).expect("failed to create output directory");
+            self.out_dir.clone()
+        }
+    }
+
+    /// Returns the binaries dir. Defaults to [`Self::out_dir`] if [`Self::binaries_dir`] is not set.
+    pub fn binaries_dir(&self) -> PathBuf {
+        if let Some(path) = &self.binaries_dir {
+            dunce::canonicalize(path).unwrap_or_else(|_| path.clone())
+        } else {
+            self.out_dir()
         }
     }
 


### PR DESCRIPTION
Currently cargo-packager expects the `Config::out_dir` value to contain the binaries to package AND uses it as the output directory. For Rust projects we manually detect the binaries output directory, so it's impossible to use a custom output directory for the packages.

This PR adds a `Config::binaries_dir` option so you can separate the package output directory and the relative-path-binaries source. With this change, it is possible to run `cargo packager ./out/packager` in a Rust project and it'll manually detect the binaries dir while using the provided output directory without crashing or failing to find the binaries.