### PR TITLE
Support using env vars for macOS notarization even if a macOS config exists

### DIFF
--- a/.changes/pr246.md
+++ b/.changes/pr246.md
@@ -1,0 +1,6 @@
+---
+"cargo-packager": "patch"
+"@crabnebula/packager": "patch"
+---
+
+On macOS, fix notarization skipping needed environment variables when macos specific config has been specified in the config file.

--- a/crates/packager/src/package/app/mod.rs
+++ b/crates/packager/src/package/app/mod.rs
@@ -152,7 +152,7 @@ pub(crate) fn package(ctx: &Context) -> crate::Result<Vec<PathBuf>> {
         codesign::try_sign(sign_paths, identity, config)?;
 
         // notarization is required for distribution
-         match config
+        match config
             .macos()
             .and_then(|m| m.notarization_credentials.clone())
             .ok_or(crate::Error::MissingNotarizeAuthVars)

--- a/crates/packager/src/package/app/mod.rs
+++ b/crates/packager/src/package/app/mod.rs
@@ -158,6 +158,7 @@ pub(crate) fn package(ctx: &Context) -> crate::Result<Vec<PathBuf>> {
                 m.notarization_credentials
                     .clone()
                     .ok_or_else(|| crate::Error::MissingNotarizeAuthVars)
+                    .or_else(|_| codesign::notarize_auth())
             })
             .unwrap_or_else(codesign::notarize_auth)
         {

--- a/crates/packager/src/package/app/mod.rs
+++ b/crates/packager/src/package/app/mod.rs
@@ -152,15 +152,11 @@ pub(crate) fn package(ctx: &Context) -> crate::Result<Vec<PathBuf>> {
         codesign::try_sign(sign_paths, identity, config)?;
 
         // notarization is required for distribution
-        match config
+         match config
             .macos()
-            .map(|m| {
-                m.notarization_credentials
-                    .clone()
-                    .ok_or_else(|| crate::Error::MissingNotarizeAuthVars)
-                    .or_else(|_| codesign::notarize_auth())
-            })
-            .unwrap_or_else(codesign::notarize_auth)
+            .and_then(|m| m.notarization_credentials.clone())
+            .ok_or(crate::Error::MissingNotarizeAuthVars)
+            .or_else(|_| codesign::notarize_auth())
         {
             Ok(auth) => {
                 tracing::debug!("Notarizing {}", app_bundle_path.display());


### PR DESCRIPTION
Thanks for this fantastic crate! We're starting to use it for packaging up some Project Robius applications.

This PR fixes a minor mistake where the notarization credentials specified via environment variables are not used if a macos-specific config (`[package.metadata.packager.macos]`) has been specified in the `Cargo.toml`, but that config section _doesn't_ include the `notification_credentials` field.

Currently there is another related bug in the schema parsing that doesn't actually allow you to provide the `notarization_credentials` in the package metadata of Cargo.toml, so this change is actually the only way to currently use the notarization features on macOS, as far as I can tell.

More specifically, when I attempt to specify the `notarization_credentials` field in `[package.metadata.packager.macos]`, I get an error about that field not existing in the schema. I'm not personally sure how to fix that, though.
However, even when that has been fixed, I still think it's beneficial to be able to specify secrets like this via env vars on the command line, instead of being required to place it in the `Cargo.toml` file, for security purposes.