### PR TITLE
feat: allow Linux dependencies to be specified via a file path

### DIFF
--- a/.changes/pr254.md
+++ b/.changes/pr254.md
@@ -1,0 +1,9 @@
+---
+"cargo-packager": "minor"
+"@crabnebula/packager": "minor"
+---
+
+Allow Linux dependencies to be specified via a file path instead of just a direct String.
+This enables the list of dependencies to by dynamically generated for both Debian `.deb` packages and pacman packages,
+which can relieve the app developer from the burden of manually maintaining a fixed list of dependencies.
+

--- a/bindings/packager/nodejs/schema.json
+++ b/bindings/packager/nodejs/schema.json
@@ -771,18 +771,19 @@
       "additionalProperties": false
     },
     "DebianConfig": {
-      "description": "The Linux debian configuration.",
+      "description": "The Linux Debian configuration.",
       "type": "object",
       "properties": {
         "depends": {
-          "description": "The list of debian dependencies.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
+          "description": "The list of Debian dependencies.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Dependencies"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "desktopTemplate": {
           "description": "Path to a custom desktop file Handlebars template.\n\nAvailable variables: `categories`, `comment` (optional), `exec`, `icon` and `name`.\n\nDefault file contents: ```text [Desktop Entry] Categories={{categories}} {{#if comment}} Comment={{comment}} {{/if}} Exec={{exec}} Icon={{icon}} Name={{name}} Terminal=false Type=Application {{#if mime_type}} MimeType={{mime_type}} {{/if}} ```",
@@ -817,6 +818,22 @@
         }
       },
       "additionalProperties": false
+    },
+    "Dependencies": {
+      "description": "A list of dependencies specified as either a list of Strings or as a path to a file that lists the dependencies, one per line.",
+      "anyOf": [
+        {
+          "description": "The list of dependencies provided directly as a vector of Strings.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "description": "A path to the file containing the list of dependences, formatted as one per line: ```text libc6 libxcursor1 libdbus-1-3 libasyncns0 ... ```",
+          "type": "string"
+        }
+      ]
     },
     "AppImageConfig": {
       "description": "The Linux AppImage configuration.",
@@ -890,14 +907,15 @@
           }
         },
         "depends": {
-          "description": "List of softwares that must be installed for the app to build and run.\n\nSee : <https://wiki.archlinux.org/title/PKGBUILD#provides>",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
+          "description": "List of softwares that must be installed for the app to build and run.\n\nSee : <https://wiki.archlinux.org/title/PKGBUILD#depends>",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Dependencies"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "provides": {
           "description": "Additional packages that are provided by this app.\n\nSee : <https://wiki.archlinux.org/title/PKGBUILD#provides>",

--- a/crates/packager/schema.json
+++ b/crates/packager/schema.json
@@ -771,18 +771,19 @@
       "additionalProperties": false
     },
     "DebianConfig": {
-      "description": "The Linux debian configuration.",
+      "description": "The Linux Debian configuration.",
       "type": "object",
       "properties": {
         "depends": {
-          "description": "The list of debian dependencies.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
+          "description": "The list of Debian dependencies.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Dependencies"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "desktopTemplate": {
           "description": "Path to a custom desktop file Handlebars template.\n\nAvailable variables: `categories`, `comment` (optional), `exec`, `icon` and `name`.\n\nDefault file contents: ```text [Desktop Entry] Categories={{categories}} {{#if comment}} Comment={{comment}} {{/if}} Exec={{exec}} Icon={{icon}} Name={{name}} Terminal=false Type=Application {{#if mime_type}} MimeType={{mime_type}} {{/if}} ```",
@@ -817,6 +818,22 @@
         }
       },
       "additionalProperties": false
+    },
+    "Dependencies": {
+      "description": "A list of dependencies specified as either a list of Strings or as a path to a file that lists the dependencies, one per line.",
+      "anyOf": [
+        {
+          "description": "The list of dependencies provided directly as a vector of Strings.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "description": "A path to the file containing the list of dependences, formatted as one per line: ```text libc6 libxcursor1 libdbus-1-3 libasyncns0 ... ```",
+          "type": "string"
+        }
+      ]
     },
     "AppImageConfig": {
       "description": "The Linux AppImage configuration.",
@@ -890,14 +907,15 @@
           }
         },
         "depends": {
-          "description": "List of softwares that must be installed for the app to build and run.\n\nSee : <https://wiki.archlinux.org/title/PKGBUILD#provides>",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
+          "description": "List of softwares that must be installed for the app to build and run.\n\nSee : <https://wiki.archlinux.org/title/PKGBUILD#depends>",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Dependencies"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "provides": {
           "description": "Additional packages that are provided by this app.\n\nSee : <https://wiki.archlinux.org/title/PKGBUILD#provides>",

--- a/crates/packager/src/config/mod.rs
+++ b/crates/packager/src/config/mod.rs
@@ -227,8 +227,9 @@ impl DebianConfig {
         I: IntoIterator<Item = S>,
         S: Into<String>,
     {
-        self.depends
-            .replace(Dependencies::List(depends.into_iter().map(Into::into).collect()));
+        self.depends.replace(Dependencies::List(
+            depends.into_iter().map(Into::into).collect(),
+        ));
         self
     }
 
@@ -236,10 +237,9 @@ impl DebianConfig {
     /// which must contain one dependency (a package name) per line.
     pub fn depends_path<P>(mut self, path: P) -> Self
     where
-        P: Into<PathBuf>
+        P: Into<PathBuf>,
     {
-        self.depends
-            .replace(Dependencies::Path(path.into()));
+        self.depends.replace(Dependencies::Path(path.into()));
         self
     }
 
@@ -298,7 +298,6 @@ impl DebianConfig {
         self
     }
 }
-
 
 /// A list of dependencies specified as either a list of Strings
 /// or as a path to a file that lists the dependencies, one per line.
@@ -500,8 +499,9 @@ impl PacmanConfig {
         I: IntoIterator<Item = S>,
         S: Into<String>,
     {
-        self.depends
-            .replace(Dependencies::List(depends.into_iter().map(Into::into).collect()));
+        self.depends.replace(Dependencies::List(
+            depends.into_iter().map(Into::into).collect(),
+        ));
         self
     }
 
@@ -509,10 +509,9 @@ impl PacmanConfig {
     /// which must contain one dependency (a package name) per line.
     pub fn depends_path<P>(mut self, path: P) -> Self
     where
-        P: Into<PathBuf>
+        P: Into<PathBuf>,
     {
-        self.depends
-            .replace(Dependencies::Path(path.into()));
+        self.depends.replace(Dependencies::Path(path.into()));
         self
     }
 

--- a/crates/packager/src/package/deb/mod.rs
+++ b/crates/packager/src/package/deb/mod.rs
@@ -280,14 +280,15 @@ fn generate_control_file(
     if let Some(homepage) = &config.homepage {
         writeln!(file, "Homepage: {}", homepage)?;
     }
-    let dependencies = config
+    if let Some(depends) = config
         .deb()
-        .cloned()
-        .and_then(|d| d.depends)
-        .unwrap_or_default();
-    if !dependencies.is_empty() {
-        writeln!(file, "Depends: {}", dependencies.join(", "))?;
-    }
+        .and_then(|d| d.depends.as_ref())
+    {
+        let dependencies = depends.to_list()?;
+        if !dependencies.is_empty() {
+            writeln!(file, "Depends: {}", dependencies.join(", "))?;
+        }
+    } 
 
     writeln!(
         file,

--- a/crates/packager/src/package/deb/mod.rs
+++ b/crates/packager/src/package/deb/mod.rs
@@ -280,15 +280,12 @@ fn generate_control_file(
     if let Some(homepage) = &config.homepage {
         writeln!(file, "Homepage: {}", homepage)?;
     }
-    if let Some(depends) = config
-        .deb()
-        .and_then(|d| d.depends.as_ref())
-    {
+    if let Some(depends) = config.deb().and_then(|d| d.depends.as_ref()) {
         let dependencies = depends.to_list()?;
         if !dependencies.is_empty() {
             writeln!(file, "Depends: {}", dependencies.join(", "))?;
         }
-    } 
+    }
 
     writeln!(
         file,

--- a/crates/packager/src/package/pacman/mod.rs
+++ b/crates/packager/src/package/pacman/mod.rs
@@ -92,8 +92,8 @@ fn generate_pkgbuild_file(
 
     let dependencies = config
         .pacman()
-        .and_then(|d| d.depends.clone())
-        .unwrap_or_default();
+        .and_then(|d| d.depends.as_ref())
+        .map_or_else(|| Ok(Vec::new()), |d| d.to_list())?;
     writeln!(file, "depends=({})", dependencies.join(" \n"))?;
 
     let provides = config


### PR DESCRIPTION
This makes it possible to dynamically generate the list of dependencies for Linux Debian and pacman package formats. 

Fixed a small documentation bug in `PacmanConfig`.

## Notes
We needed this feature in Project Robius to relieve the app dev from the burdens of:
1. figuring out which dependencies their app binaries need.
2. having to keep that list up to date when adding or removing dependencies from their app, which typically is only done at the Rust crate level (rather than the Linux native package/library level).

This changeset has been tested to work for us on Ubuntu LTS 20.04, 22.04, and 24.04, on both aarch64 and x86_64.

Question: I modified the `crates/packager/schema.json` file by hand -- not sure if that's correct or if it's generated automatically. It appears that `bindings/packager/nodejs/schema.json` was indeed auto-generated; not sure if that needs to be committed too. Please advise, thanks!

