### PR TITLE
docs(macos): explicitly mention which fields are skipped

### DIFF
--- a/.changes/pr255.md
+++ b/.changes/pr255.md
@@ -1,0 +1,11 @@
+---
+"cargo-packager": "patch"
+"@crabnebula/packager": "patch"
+---
+
+Explicitly mention which fields in `Config` and other configuration structs
+are skipped during deserialization.
+This reduces confusion for new users looking at the docs for `Config`,
+who may receive unexpected errors when attempting to specify skipped fields
+in their config files or Cargo package metadata.     
+

--- a/crates/packager/src/config/mod.rs
+++ b/crates/packager/src/config/mod.rs
@@ -624,15 +624,23 @@ pub struct MacOsConfig {
     #[serde(alias = "exception-domain", alias = "exception_domain")]
     pub exception_domain: Option<String>,
     /// Code signing identity.
+    ///
+    /// This is typically of the form: `"Developer ID Application: TEAM_NAME (TEAM_ID)"`.
     #[serde(alias = "signing-identity", alias = "signing_identity")]
     pub signing_identity: Option<String>,
     /// Codesign certificate (base64 encoded of the p12 file).
+    ///
+    /// Note: this field cannot be specified via a config file or Cargo package metadata.
     #[serde(skip)]
     pub signing_certificate: Option<OsString>,
     /// Password of the codesign certificate.
+    ///
+    /// Note: this field cannot be specified via a config file or Cargo package metadata.
     #[serde(skip)]
     pub signing_certificate_password: Option<OsString>,
     /// Notarization authentication credentials.
+    ///
+    /// Note: this field cannot be specified via a config file or Cargo package metadata.
     #[serde(skip)]
     pub notarization_credentials: Option<MacOsNotarizationCredentials>,
     /// Provider short name for notarization.


### PR DESCRIPTION
New users may be confused when looking at the docs for `Config` and other config-like structs, as some fields cannot be specified in config files or via Cargo's package metadata.
This commit clarifies that those fields are intentionally excluded.

Also added an example of a macOS developer signing identity.

## Notes
I added this notice to the docs of only 3 fields, those that were annotated with `#[serde(skip)]`. Let me know if there are any other fields that should have this notice too.