### PR TITLE
fix(dmg): canonicalize path returns from `create_icns_file`

### DIFF
--- a/.changes/fix-dmg-failed-with-out-dir.md
+++ b/.changes/fix-dmg-failed-with-out-dir.md
@@ -1,0 +1,5 @@
+---
+"cargo-packager": patch
+---
+
+Fixed dmg failed to bundle the application when out-dir does not exist.

--- a/crates/packager/src/config/mod.rs
+++ b/crates/packager/src/config/mod.rs
@@ -1792,13 +1792,13 @@ impl Config {
     /// Returns the out dir. Defaults to the current directory.
     pub fn out_dir(&self) -> PathBuf {
         if self.out_dir.as_os_str().is_empty() {
-            std::env::current_dir().expect("failed to resolve cwd")
-        } else if self.out_dir.exists() {
-            dunce::canonicalize(&self.out_dir).unwrap_or_else(|_| self.out_dir.clone())
-        } else {
-            std::fs::create_dir_all(&self.out_dir).expect("failed to create output directory");
-            self.out_dir.clone()
+            return std::env::current_dir().expect("failed to resolve cwd");
         }
+
+        if !self.out_dir.exists() {
+            std::fs::create_dir_all(&self.out_dir).expect("failed to create output directory");
+        }
+        dunce::canonicalize(&self.out_dir).unwrap_or_else(|_| self.out_dir.clone())
     }
 
     /// Returns the binaries dir. Defaults to [`Self::out_dir`] if [`Self::binaries_dir`] is not set.

--- a/crates/packager/src/util.rs
+++ b/crates/packager/src/util.rs
@@ -315,7 +315,7 @@ pub fn create_icns_file(out_dir: &Path, config: &crate::Config) -> crate::Result
                 );
                 std::fs::copy(&icon_path, &dest_path)?;
 
-                return Ok(Some(dest_path));
+                return Ok(Some(dunce::canonicalize(dest_path)?));
             }
         }
     }
@@ -379,7 +379,7 @@ pub fn create_icns_file(out_dir: &Path, config: &crate::Config) -> crate::Result
         dest_path.set_extension("icns");
         let icns_file = std::io::BufWriter::new(File::create(&dest_path)?);
         family.write(icns_file)?;
-        Ok(Some(dest_path))
+        Ok(Some(dunce::canonicalize(dest_path)?))
     } else {
         Err(crate::Error::InvalidIconList)
     }

--- a/crates/packager/src/util.rs
+++ b/crates/packager/src/util.rs
@@ -315,7 +315,7 @@ pub fn create_icns_file(out_dir: &Path, config: &crate::Config) -> crate::Result
                 );
                 std::fs::copy(&icon_path, &dest_path)?;
 
-                return Ok(Some(dunce::canonicalize(dest_path)?));
+                return Ok(Some(dest_path));
             }
         }
     }
@@ -379,7 +379,7 @@ pub fn create_icns_file(out_dir: &Path, config: &crate::Config) -> crate::Result
         dest_path.set_extension("icns");
         let icns_file = std::io::BufWriter::new(File::create(&dest_path)?);
         family.write(icns_file)?;
-        Ok(Some(dunce::canonicalize(dest_path)?))
+        Ok(Some(dest_path))
     } else {
         Err(crate::Error::InvalidIconList)
     }


### PR DESCRIPTION
When `out-dir` is provided but does not exist, `create_icns_file()` returns a relative path (out/dir/icon.icns). Calling the `create-dmg` script will change the working dir to `out-dir`. When copying the volume icon, the icon does not exist at the path (out/dir/out/dir/icon.icns).