### PR TITLE
fix(pacman): enclose directory paths in `PKGBUILD` in double quotes

### DIFF
--- a/.changes/pr_264.md
+++ b/.changes/pr_264.md
@@ -1,0 +1,7 @@
+---
+"cargo-packager": patch
+"@crabnebula/packager": patch
+---
+
+Fix `pacman` package failing to install when source directory contained whitespace.
+

--- a/crates/packager/src/package/pacman/mod.rs
+++ b/crates/packager/src/package/pacman/mod.rs
@@ -133,7 +133,7 @@ fn generate_pkgbuild_file(
     let sha_hash = sha512.finalize();
 
     writeln!(file, "sha512sums=(\"{:x}\")", sha_hash)?;
-    writeln!(file, "package() {{\n\tcp -r ${{srcdir}}/* ${{pkgdir}}/\n}}")?;
+    writeln!(file, "package() {{\n\tcp -r \"${{srcdir}}\"/* \"${{pkgdir}}\"/\n}}")?;
 
     file.flush()?;
     Ok(())


### PR DESCRIPTION
This ensures that paths with spaces on the target machine are properly preserved during pacman's installation of the package.

Context: some users of our Moxin app that was packaged for Arch Linux using `cargo-packager` reported that their pacman install command was failing due to paths containing whitespace.
Thanks to @cassaundra for proposing this fix and confirming that it works.