### PR TITLE
chore: point to full URL in img

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cargo-packager
 
-<img src="https://github.com/crabnebula-dev/cargo-packager/raw/HEAD/crates/packager/.github/splash.png" alt="cargo-packager splash" />
+<img src="https://raw.githubusercontent.com/crabnebula-dev/cargo-packager/main/.github/splash.png" alt="cargo-packager splash" />
 
 Executable packager, bundler and updater. A cli tool and library to generate installers or app bundles for your executables.
 It also has a compatible updater through [cargo-packager-updater](./crates/updater/).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cargo-packager
 
-<img src=".github/splash.png" alt="cargo-packager splash" />
+<img src="https://github.com/crabnebula-dev/cargo-packager/raw/HEAD/crates/packager/.github/splash.png" alt="cargo-packager splash" />
 
 Executable packager, bundler and updater. A cli tool and library to generate installers or app bundles for your executables.
 It also has a compatible updater through [cargo-packager-updater](./crates/updater/).


### PR DESCRIPTION
Relative URLs are broken on https://crates.io/crates/cargo-packager. This replaces the URL with a full one.