### PR TITLE
fix(nsis): resources paths when cross compiling

### DIFF
--- a/.changes/fix-nsis-resources-cross-compiling.md
+++ b/.changes/fix-nsis-resources-cross-compiling.md
@@ -1,5 +1,6 @@
 ---
 "cargo-packager": patch
+"@crabnebula/packager": patch
 ---
 
 Fixes resources paths on NSIS when cross compiling.

--- a/.changes/fix-nsis-resources-cross-compiling.md
+++ b/.changes/fix-nsis-resources-cross-compiling.md
@@ -1,0 +1,5 @@
+---
+"cargo-packager": patch
+---
+
+Fixes resources paths on NSIS when cross compiling.

--- a/crates/packager/src/package/nsis/mod.rs
+++ b/crates/packager/src/package/nsis/mod.rs
@@ -72,6 +72,7 @@ fn normalize_resource_path<P: AsRef<Path>>(path: P) -> PathBuf {
 }
 
 // We need to convert / to \ for nsis to move the files into the correct dirs
+#[cfg(not(windows))]
 fn normalize_resource_path<P: AsRef<Path>>(path: P) -> PathBuf {
     path.as_ref()
         .display()


### PR DESCRIPTION
pulling a fix in the tauri bundler that we did not port yet 