### PR TITLE
feat: add config option to disable linux desktop entry

### DIFF
--- a/.changes/disable-desktop-entry.md
+++ b/.changes/disable-desktop-entry.md
@@ -1,0 +1,6 @@
+---
+"cargo-packager": patch
+"@crabnebula/packager": patch
+---
+
+Added `linux > generateDesktopEntry` config to allow disabling generating a .desktop file on Linux bundles (defaults to true).

--- a/bindings/packager/nodejs/schema.json
+++ b/bindings/packager/nodejs/schema.json
@@ -802,14 +802,13 @@
       "description": "Linux configuration",
       "type": "object",
       "properties": {
-        "generate_desktop_entry": {
+        "generateDesktopEntry": {
           "description": "Flag to indicate if desktop entry should be generated.",
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "default": true,
+          "type": "boolean"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "DebianConfig": {
       "description": "The Linux Debian configuration.",

--- a/bindings/packager/nodejs/schema.json
+++ b/bindings/packager/nodejs/schema.json
@@ -248,6 +248,17 @@
         }
       ]
     },
+    "linux": {
+      "description": "Linux-specific configuration",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/LinuxConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "deb": {
       "description": "Debian-specific configuration.",
       "anyOf": [
@@ -786,6 +797,19 @@
         }
       },
       "additionalProperties": false
+    },
+    "LinuxConfig": {
+      "description": "Linux configuration",
+      "type": "object",
+      "properties": {
+        "generate_desktop_entry": {
+          "description": "Flag to indicate if desktop entry should be generated.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
     },
     "DebianConfig": {
       "description": "The Linux Debian configuration.",

--- a/crates/packager/schema.json
+++ b/crates/packager/schema.json
@@ -802,14 +802,13 @@
       "description": "Linux configuration",
       "type": "object",
       "properties": {
-        "generate_desktop_entry": {
+        "generateDesktopEntry": {
           "description": "Flag to indicate if desktop entry should be generated.",
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "default": true,
+          "type": "boolean"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "DebianConfig": {
       "description": "The Linux Debian configuration.",

--- a/crates/packager/schema.json
+++ b/crates/packager/schema.json
@@ -248,6 +248,17 @@
         }
       ]
     },
+    "linux": {
+      "description": "Linux-specific configuration",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/LinuxConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "deb": {
       "description": "Debian-specific configuration.",
       "anyOf": [
@@ -786,6 +797,19 @@
         }
       },
       "additionalProperties": false
+    },
+    "LinuxConfig": {
+      "description": "Linux configuration",
+      "type": "object",
+      "properties": {
+        "generate_desktop_entry": {
+          "description": "Flag to indicate if desktop entry should be generated.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
     },
     "DebianConfig": {
       "description": "The Linux Debian configuration.",

--- a/crates/packager/src/config/mod.rs
+++ b/crates/packager/src/config/mod.rs
@@ -838,17 +838,16 @@ impl MacOsConfig {
 /// Linux configuration
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct LinuxConfig {
     /// Flag to indicate if desktop entry should be generated.
-    pub generate_desktop_entry: Option<bool>
-}
-
-impl LinuxConfig {
-    /// Should desktop entry be generated in linux packaging. Defaults to true.
-    pub fn generate_desktop_entry(&self) -> bool {
-        self.generate_desktop_entry.unwrap_or(true)
-    }
+    #[serde(
+        default = "default_true",
+        alias = "generate-desktop-entry",
+        alias = "generate_desktop_entry"
+    )]
+    pub generate_desktop_entry: bool,
 }
 
 /// A wix language.

--- a/crates/packager/src/config/mod.rs
+++ b/crates/packager/src/config/mod.rs
@@ -835,6 +835,22 @@ impl MacOsConfig {
     }
 }
 
+/// Linux configuration
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[non_exhaustive]
+pub struct LinuxConfig {
+    /// Flag to indicate if desktop entry should be generated.
+    pub generate_desktop_entry: Option<bool>
+}
+
+impl LinuxConfig {
+    /// Should desktop entry be generated in linux packaging. Defaults to true.
+    pub fn generate_desktop_entry(&self) -> bool {
+        self.generate_desktop_entry.unwrap_or(true)
+    }
+}
+
 /// A wix language.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -1710,6 +1726,8 @@ pub struct Config {
     pub windows: Option<WindowsConfig>,
     /// MacOS-specific configuration.
     pub macos: Option<MacOsConfig>,
+    /// Linux-specific configuration
+    pub linux: Option<LinuxConfig>,
     /// Debian-specific configuration.
     pub deb: Option<DebianConfig>,
     /// AppImage configuration.
@@ -1738,6 +1756,11 @@ impl Config {
     /// Returns the [macos](Config::macos) specific configuration.
     pub fn macos(&self) -> Option<&MacOsConfig> {
         self.macos.as_ref()
+    }
+
+    /// Returns the [linux](Config::linux) specific configuration.
+    pub fn linux(&self) -> Option<&LinuxConfig> {
+        self.linux.as_ref()
     }
 
     /// Returns the [nsis](Config::nsis) specific configuration.

--- a/crates/packager/src/package/app/mod.rs
+++ b/crates/packager/src/package/app/mod.rs
@@ -317,13 +317,13 @@ fn create_info_plist(
 
     plist.insert("LSRequiresCarbon".into(), true.into());
     plist.insert("NSHighResolutionCapable".into(), true.into());
-    
+
     if let Some(macos_config) = config.macos() {
         if macos_config.background_app {
             plist.insert("LSUIElement".into(), true.into());
         }
     }
-    
+
     if let Some(copyright) = &config.copyright {
         plist.insert("NSHumanReadableCopyright".into(), copyright.clone().into());
     }

--- a/crates/packager/src/package/deb/mod.rs
+++ b/crates/packager/src/package/deb/mod.rs
@@ -208,14 +208,14 @@ pub fn generate_data(config: &Config, data_dir: &Path) -> crate::Result<BTreeSet
     tracing::debug!("Generating icons");
     let icons = generate_icon_files(config, data_dir)?;
 
-    if let Some(linux_conf) = config.linux() {
-        if !linux_conf.generate_desktop_entry() {
-            return Ok(icons);
-        }
-    }
+    let generate_desktop_entry = config
+        .linux()
+        .map_or(true, |linux| linux.generate_desktop_entry);
 
-    tracing::debug!("Generating desktop file");
-    generate_desktop_file(config, data_dir)?;
+    if generate_desktop_entry {
+        tracing::debug!("Generating desktop file");
+        generate_desktop_file(config, data_dir)?;
+    }
 
     Ok(icons)
 }

--- a/crates/packager/src/package/deb/mod.rs
+++ b/crates/packager/src/package/deb/mod.rs
@@ -208,6 +208,12 @@ pub fn generate_data(config: &Config, data_dir: &Path) -> crate::Result<BTreeSet
     tracing::debug!("Generating icons");
     let icons = generate_icon_files(config, data_dir)?;
 
+    if let Some(linux_conf) = config.linux() {
+        if !linux_conf.generate_desktop_entry() {
+            return Ok(icons);
+        }
+    }
+
     tracing::debug!("Generating desktop file");
     generate_desktop_file(config, data_dir)?;
 


### PR DESCRIPTION
- CLI applications do not need to have desktop entries.
- Additionally, this should also help applications that want to use their own Desktop entries for all the packages.
- Currently, there seems to be an option to specify custom desktop entry template in debconfig, but not appimage and pacman. 
- By using this option, it should be possible to just use their own destkop entry as a normal package file.