### PR TITLE
feat(macos): add background-app configuration to support LSUIElement in Info.plist

### DIFF
--- a/.changes/macos-background-app.md
+++ b/.changes/macos-background-app.md
@@ -1,0 +1,6 @@
+---
+"cargo-packager": patch
+"@crabnebula/packager": patch
+---
+
+Add `background-app` config setting for macOS to set `LSUIElement` to `true`.

--- a/bindings/packager/nodejs/schema.json
+++ b/bindings/packager/nodejs/schema.json
@@ -783,6 +783,11 @@
           "items": {
             "type": "string"
           }
+        },
+        "backgroundApp": {
+          "description": "Whether this is a background application. If true, the app will not appear in the Dock.\n\nSets the `LSUIElement` flag in the macOS plist file.",
+          "default": false,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/bindings/packager/nodejs/src-ts/config.d.ts
+++ b/bindings/packager/nodejs/src-ts/config.d.ts
@@ -437,6 +437,12 @@ export interface MacOsConfig {
    * Apps that need to be packaged within the app.
    */
   embeddedApps?: string[] | null;
+  /**
+   * Whether this is a background application. If true, the app will not appear in the Dock.
+   * 
+   * Sets the `LSUIElement` flag in the macOS plist file.
+   */
+  backgroundApp?: boolean;
 }
 /**
  * The Linux Debian configuration.

--- a/crates/packager/schema.json
+++ b/crates/packager/schema.json
@@ -783,6 +783,11 @@
           "items": {
             "type": "string"
           }
+        },
+        "backgroundApp": {
+          "description": "Whether this is a background application. If true, the app will not appear in the Dock.\n\nSets the `LSUIElement` flag in the macOS plist file.",
+          "default": false,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/crates/packager/src/config/mod.rs
+++ b/crates/packager/src/config/mod.rs
@@ -745,6 +745,11 @@ pub struct MacOsConfig {
     /// Apps that need to be packaged within the app.
     #[serde(alias = "embedded-apps", alias = "embedded_apps")]
     pub embedded_apps: Option<Vec<String>>,
+    /// Whether this is a background application. If true, the app will not appear in the Dock.
+    ///
+    /// Sets the `LSUIElement` flag in the macOS plist file.
+    #[serde(default, alias = "background_app", alias = "background-app")]
+    pub background_app: bool,
 }
 
 impl MacOsConfig {

--- a/crates/packager/src/package/app/mod.rs
+++ b/crates/packager/src/package/app/mod.rs
@@ -317,6 +317,13 @@ fn create_info_plist(
 
     plist.insert("LSRequiresCarbon".into(), true.into());
     plist.insert("NSHighResolutionCapable".into(), true.into());
+    
+    if let Some(macos_config) = config.macos() {
+        if macos_config.background_app {
+            plist.insert("LSUIElement".into(), true.into());
+        }
+    }
+    
     if let Some(copyright) = &config.copyright {
         plist.insert("NSHumanReadableCopyright".into(), copyright.clone().into());
     }


### PR DESCRIPTION
Adds a new config setting for `background-app` specific to macOS that sets [LSUIElement](https://developer.apple.com/documentation/bundleresources/information-property-list/lsuielement) to true in the Info.plist.

This tells macOS the app is an "agent" app and is to run in the background with no icon in the Dock - particularly useful for menubar based apps that have no main window.

Have validated this works locally. Hopefully I have updated everything required!