### PR TITLE
packager: deb: Add package_name config var

### DIFF
--- a/bindings/packager/nodejs/schema.json
+++ b/bindings/packager/nodejs/schema.json
@@ -860,6 +860,13 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "packageName": {
+          "description": "Overwrite package name just for deb.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false

--- a/crates/packager/schema.json
+++ b/crates/packager/schema.json
@@ -860,6 +860,13 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "packageName": {
+          "description": "Overwrite package name just for deb.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false

--- a/crates/packager/src/config/mod.rs
+++ b/crates/packager/src/config/mod.rs
@@ -231,6 +231,9 @@ pub struct DebianConfig {
     /// List of custom files to add to the deb package.
     /// Maps a dir/file to a dir/file inside the debian package.
     pub files: Option<HashMap<String, String>>,
+    /// Overwrite package name just for deb.
+    #[serde(alias = "package-name", alias = "package_name")]
+    pub package_name: Option<String>
 }
 
 impl DebianConfig {

--- a/crates/packager/src/package/deb/mod.rs
+++ b/crates/packager/src/package/deb/mod.rs
@@ -302,7 +302,14 @@ fn generate_control_file(
     // https://www.debian.org/doc/debian-policy/ch-controlfields.html
     let dest_path = control_dir.join("control");
     let mut file = util::create_file(&dest_path)?;
-    writeln!(file, "Package: {}", AsKebabCase(&config.product_name))?;
+
+    let pkg_name = AsKebabCase(&config.product_name).to_string();
+    let pkg_name: String = config
+        .deb()
+        .map(|x| x.package_name.clone().unwrap_or(pkg_name.clone()))
+        .unwrap_or(pkg_name);
+
+    writeln!(file, "Package: {}", pkg_name)?;
     writeln!(file, "Version: {}", &config.version)?;
     writeln!(file, "Architecture: {}", arch)?;
     // Installed-Size must be divided by 1024, see https://www.debian.org/doc/debian-policy/ch-controlfields.html#installed-size


### PR DESCRIPTION
- Allow specifying the debian package name instead of guessing from product name.