### PR TITLE
ci(deny): Allow Unicode-3.0 license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -29,6 +29,7 @@ allow = [
     "ISC",
     # Apparently for us it's equivalent to BSD-3 which is considered compatible with MIT and Apache-2.0
     "Unicode-DFS-2016",
+    "Unicode-3.0",
     # Used by webpki-roots and option-ext which we are using without modifications in a larger work, therefore okay.
     "MPL-2.0",
     "BSD-3-Clause",


### PR DESCRIPTION
from what i saw in discussions Unicode-3.0 seems to be the same or really similar to Unicode-DFS-2016 which we already allow. please double check this yourself though, all that license speak is way over my head.