### PR TITLE
Add a `MacOsNotarizationCredentials` variant to use a keychain profile for notarytool settings and password.

### DIFF
--- a/.changes/notarize-keychain.md
+++ b/.changes/notarize-keychain.md
@@ -1,0 +1,6 @@
+---
+"cargo-packager": patch
+"@crabnebula/packager": patch
+---
+
+Allow using notarization credentials stored on the Keychain by providing the `APPLE_KEYCHAIN_PROFILE` environment variable. See `xcrun notarytool store-credentials` for more information.

--- a/crates/packager/src/config/mod.rs
+++ b/crates/packager/src/config/mod.rs
@@ -682,13 +682,13 @@ pub enum MacOsNotarizationCredentials {
     },
     /// Keychain profile with a stored app-specific password for notarytool to use
     /// Passwords can be generated at https://account.apple.com when signed in with your developer account.
-    /// The password must then be stored in your keychain for naotarytool to access,
-    /// using the following, with the appopriate Apple and Team id:
+    /// The password must then be stored in your keychain for notarytool to access,
+    /// using the following, with the appopriate Apple and Team IDs:
     /// `xcrun notarytool store-credentials --apple-id "name@example.com" --team-id "ABCD123456"`
     /// This will prompt for a keychain profile name, and the password itself.
     /// This setting can only be provided as an environment variable "APPLE_KEYCHAIN_PROFILE"
     KeychainProfile {
-        /// The keychain profile name (as provided when the password was strored using notarytool)
+        /// The keychain profile name (as provided when the password was stored using notarytool)
         keychain_profile: OsString,
     },
 }

--- a/crates/packager/src/config/mod.rs
+++ b/crates/packager/src/config/mod.rs
@@ -680,6 +680,17 @@ pub enum MacOsNotarizationCredentials {
         /// Path to the API key file.
         key_path: PathBuf,
     },
+    /// Keychain profile with a stored app-specific password for notarytool to use
+    /// Passwords can be generated at https://account.apple.com when signed in with your developer account.
+    /// The password must then be stored in your keychain for naotarytool to access,
+    /// using the following, with the appopriate Apple and Team id:
+    /// `xcrun notarytool store-credentials --apple-id "name@example.com" --team-id "ABCD123456"`
+    /// This will prompt for a keychain profile name, and the password itself.
+    /// This setting can only be provided as an environment variable "APPLE_KEYCHAIN_PROFILE"
+    KeychainProfile {
+        /// The keychain profile name (as provided when the password was strored using notarytool)
+        keychain_profile: OsString,
+    },
 }
 
 /// The macOS configuration.


### PR DESCRIPTION
This allows `notarytool` to use an Apple ID, Team ID and app-specific password stored in the keychain, by just providing the keychain profile as an env var (`"APPLE_KEYCHAIN_PROFILE"`). This reduces the number of env vars needed, and means the password isn't in a variable as plain text.

This approach is described under "Upload your app to the notarization service" here: https://developer.apple.com/documentation/security/customizing-the-notarization-workflow

Resolves #352