### PR TITLE
fix(linux): pull latest linuxdeploy appimage plugin

### DIFF
--- a/.changes/update-appimage-plugin.md
+++ b/.changes/update-appimage-plugin.md
@@ -1,0 +1,6 @@
+---
+"cargo-packager": patch
+"@crabnebula/packager": patch
+---
+
+Updated linuxdeploy's AppImage plugin to not require libfuse on the user's system anymore.

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
       - run: cargo install cargo-binstall --locked
-      - run: cargo binstall tauri-cli
-      - run: cargo binstall dioxus-cli
+      - run: cargo binstall tauri-cli --locked
+      - run: cargo binstall dioxus-cli --locked --force
       - run: cargo r --package cargo-packager -- signer generate --password '123' --path ./signing-key -vvv
       - run: cargo r --package cargo-packager -- --release --private-key ./signing-key --password '123' --formats all -vvv

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
       - run: cargo install cargo-binstall --locked
-      - run: cargo binstall tauri-cli --locked
+      - run: cargo binstall tauri-cli --locked --force
       - run: cargo binstall dioxus-cli --locked --force
       - run: cargo r --package cargo-packager -- signer generate --password '123' --path ./signing-key -vvv
       - run: cargo r --package cargo-packager -- --release --private-key ./signing-key --password '123' --formats all -vvv

--- a/crates/packager/src/package/appimage/mod.rs
+++ b/crates/packager/src/package/appimage/mod.rs
@@ -34,7 +34,7 @@ fn donwload_dependencies(
         ),
         // This path is incompatible with cross-platform compilation but linuxdeploy doens't support that anyway.
         (
-            format!("linuxdeploy-plugin-appimage.AppImage"),
+            "linuxdeploy-plugin-appimage.AppImage".to_string(),
             format!("https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-{arch}.AppImage")
         ),
     ];

--- a/crates/packager/src/package/appimage/mod.rs
+++ b/crates/packager/src/package/appimage/mod.rs
@@ -32,8 +32,9 @@ fn donwload_dependencies(
             format!("linuxdeploy-{linuxdeploy_arch}.AppImage"),
             format!("https://github.com/tauri-apps/binary-releases/releases/download/linuxdeploy/linuxdeploy-{linuxdeploy_arch}.AppImage")
         ),
+        // This path is incompatible with cross-platform compilation but linuxdeploy doens't support that anyway.
         (
-            format!("linuxdeploy-{arch}.AppImage"),
+            format!("linuxdeploy-plugin-appimage.AppImage"),
             format!("https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-{arch}.AppImage")
         ),
     ];

--- a/crates/packager/src/package/appimage/mod.rs
+++ b/crates/packager/src/package/appimage/mod.rs
@@ -32,6 +32,10 @@ fn donwload_dependencies(
             format!("linuxdeploy-{linuxdeploy_arch}.AppImage"),
             format!("https://github.com/tauri-apps/binary-releases/releases/download/linuxdeploy/linuxdeploy-{linuxdeploy_arch}.AppImage")
         ),
+        (
+            format!("linuxdeploy-{arch}.AppImage"),
+            format!("https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-{arch}.AppImage")
+        ),
     ];
 
     let user_deps = ctx

--- a/deny.toml
+++ b/deny.toml
@@ -31,7 +31,7 @@ allow = [
     "Unicode-DFS-2016",
     "Unicode-3.0",
     # Used by webpki-roots and option-ext which we are using without modifications in a larger work, therefore okay.
-    "CDLA-Permissive-2.0"
+    "CDLA-Permissive-2.0",
     "MPL-2.0",
     "BSD-3-Clause",
     "BSD-2-Clause",

--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,7 @@ allow = [
     "Unicode-DFS-2016",
     "Unicode-3.0",
     # Used by webpki-roots and option-ext which we are using without modifications in a larger work, therefore okay.
+    "CDLA-Permissive-2.0"
     "MPL-2.0",
     "BSD-3-Clause",
     "BSD-2-Clause",


### PR DESCRIPTION
closes #361

like in tauri i'd rather not touch linuxdeploy as a whole at the moment but this should work for this repo at least. i also plan to drop the use of linuxdeploy here in favor of sharun in the future, ref https://github.com/tauri-apps/tauri/pull/12491