### PR TITLE
Change nsi template from using `association.ext` to `association.extensions`, to match struct field in `FileAssociation`.

### DIFF
--- a/.changes/fix-nsis-file-associations.md
+++ b/.changes/fix-nsis-file-associations.md
@@ -1,0 +1,7 @@
+---
+"cargo-packager": patch
+"@crabnebula/packager": patch
+---
+
+Change nsi template from using `association.ext` to `association.extensions`, to match struct field in `FileAssociation`.
+This allows file associations to be generated in `.nsi` files, and therefore in the final NSIS installer.

--- a/crates/packager/src/package/nsis/installer.nsi
+++ b/crates/packager/src/package/nsis/installer.nsi
@@ -492,9 +492,9 @@ Section Install
     File /a "/oname={{this}}" "{{@key}}"
   {{/each}}
 
-   ; Create file associations
+  ; Create file associations
   {{#each file_associations as |association| ~}}
-    {{#each association.ext as |ext| ~}}
+    {{#each association.extensions as |ext| ~}}
        !insertmacro APP_ASSOCIATE "{{ext}}" "{{or association.name ext}}" "{{association-description association.description ext}}" "$INSTDIR\${MAINBINARYNAME}.exe,0" "Open with ${PRODUCTNAME}" "$INSTDIR\${MAINBINARYNAME}.exe $\"%1$\""
     {{/each}}
   {{/each}}


### PR DESCRIPTION
This allows file associations to be generated in `.nsi` files, and therefore in the final NSIS installer.

Fixes #364