### PR TITLE
Create `latest.json` build artefact for updater endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,6 +1262,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq",
+ "url",
  "uuid",
  "walkdir",
  "windows-registry",

--- a/bindings/packager/nodejs/schema.json
+++ b/bindings/packager/nodejs/schema.json
@@ -324,6 +324,14 @@
           "type": "null"
         }
       ]
+    },
+    "endpoint": {
+      "description": "When set, a summary `latest.json` build artefact will be generated which can be hosted alongside other build artefacts as an endpoint for the updater, including meta data about the version and URL's to point at each of the other build artefacts.\n\nSpecifically, this URL specifies where these build artefacts are hosted. For example, a using Github Releases: `https://github.com/org/repo/releases/download/v{{version}}/{{artefact}}`\n\nEach endpoint optionally could have `{{version}}` or `{{artefact}}` which will be detected and replaced with the appropriate value\n\n- `{{version}}`: The version of the app which is being packaged - `{{artefact}}`: The file name of the particular build artefact One URL is produced per build artefact.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "uri"
     }
   },
   "additionalProperties": false,

--- a/crates/packager/Cargo.toml
+++ b/crates/packager/Cargo.toml
@@ -85,6 +85,7 @@ time = { workspace = true, features = ["formatting"] }
 image = { version = "0.25", default-features = false, features = ["rayon", "bmp", "ico", "png", "jpeg"] }
 tempfile = "3"
 plist = "1"
+url = { version = "2", features = ["serde"] }
 
 [target."cfg(target_os = \"windows\")".dependencies]
 windows-registry = "0.5"

--- a/crates/packager/schema.json
+++ b/crates/packager/schema.json
@@ -324,6 +324,14 @@
           "type": "null"
         }
       ]
+    },
+    "endpoint": {
+      "description": "When set, a summary `latest.json` build artefact will be generated which can be hosted alongside other build artefacts as an endpoint for the updater, including meta data about the version and URL's to point at each of the other build artefacts.\n\nSpecifically, this URL specifies where these build artefacts are hosted. For example, a using Github Releases: `https://github.com/org/repo/releases/download/v{{version}}/{{artefact}}`\n\nEach endpoint optionally could have `{{version}}` or `{{artefact}}` which will be detected and replaced with the appropriate value\n\n- `{{version}}`: The version of the app which is being packaged - `{{artefact}}`: The file name of the particular build artefact One URL is produced per build artefact.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "uri"
     }
   },
   "additionalProperties": false,

--- a/crates/packager/src/cli/mod.rs
+++ b/crates/packager/src/cli/mod.rs
@@ -10,7 +10,8 @@ use clap::{ArgAction, CommandFactory, FromArgMatches, Parser, Subcommand};
 
 use crate::{
     config::{LogLevel, PackageFormat},
-    init_tracing_subscriber, package, parse_log_level, sign_outputs, util, SigningConfig,
+    init_tracing_subscriber, package, parse_log_level, sign_outputs, summarise_outputs, util,
+    SigningConfig,
 };
 
 mod config;
@@ -137,6 +138,7 @@ fn run_cli(cli: Cli) -> Result<()> {
 
     let mut outputs = Vec::new();
     let mut signatures = Vec::new();
+    let mut summaries = Vec::new();
     for (config_dir, mut config) in configs {
         tracing::trace!(config = ?config);
 
@@ -182,6 +184,9 @@ fn run_cli(cli: Cli) -> Result<()> {
             signatures.extend(s);
         }
 
+        // build summary
+        summaries.push(summarise_outputs(&config, &mut packages)?);
+
         outputs.extend(packages);
     }
 
@@ -189,6 +194,7 @@ fn run_cli(cli: Cli) -> Result<()> {
     let outputs = outputs
         .into_iter()
         .flat_map(|o| o.paths)
+        .chain(summaries.into_iter())
         .collect::<Vec<_>>();
 
     // print information when finished

--- a/crates/packager/src/cli/signer/sign.rs
+++ b/crates/packager/src/cli/signer/sign.rs
@@ -42,7 +42,7 @@ pub fn command(options: Options) -> Result<()> {
 
     tracing::info!(
         "Signed the file successfully! find the signature at: {}",
-        signature_path.display()
+        signature_path.0.display()
     );
 
     Ok(())

--- a/crates/packager/src/config/mod.rs
+++ b/crates/packager/src/config/mod.rs
@@ -1827,7 +1827,7 @@ impl Config {
         let target = self.target_triple();
         if target.contains("windows") {
             Some("windows")
-        } else if target.contains("macos") {
+        } else if target.contains("apple-darwin") {
             Some("macos")
         } else if target.contains("linux") {
             Some("linux")

--- a/crates/packager/src/error.rs
+++ b/crates/packager/src/error.rs
@@ -250,6 +250,9 @@ pub enum Error {
     /// Failed to enumerate registry keys.
     #[error("failed to enumerate registry keys")]
     FailedToEnumerateRegKeys,
+    /// Url parsing errors.
+    #[error(transparent)]
+    UrlParse(#[from] url::ParseError),
 }
 
 /// Convenient type alias of Result type for cargo-packager.

--- a/crates/packager/src/lib.rs
+++ b/crates/packager/src/lib.rs
@@ -261,12 +261,12 @@ pub fn summarise_outputs(
 
     for package in packages {
         if let Some(summary) = package.summary.clone() {
-            if summary.signature.is_some() {
-                platforms.insert(summary.platform.clone(), summary);
-            } else {
-                // The signer failed to update the signature field
-                tracing::warn!("A package could not be summarized in latest.json because it could not be signed.")
-            }
+            // if summary.signature.is_some() {
+            platforms.insert(summary.platform.clone(), summary);
+            // } else {
+            //     // The signer failed to update the signature field
+            //     tracing::warn!("A package could not be summarized in latest.json because it could not be signed.")
+            // }
         }
     }
 

--- a/crates/packager/src/lib.rs
+++ b/crates/packager/src/lib.rs
@@ -76,7 +76,7 @@
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![deny(missing_docs)]
 
-use std::{io::Write, path::PathBuf};
+use std::{collections::HashMap, fs::File, io::Write, path::PathBuf};
 
 mod codesign;
 mod error;
@@ -93,10 +93,13 @@ pub mod sign;
 pub use config::{Config, PackageFormat};
 pub use error::{Error, Result};
 use flate2::{write::GzEncoder, Compression};
+use serde::Serialize;
 pub use sign::SigningConfig;
 
 pub use package::{package, PackageOutput};
 use util::PathExt;
+
+use crate::package::PackageOutputSummary;
 
 #[cfg(feature = "cli")]
 fn parse_log_level(verbose: u8) -> tracing::Level {
@@ -225,11 +228,69 @@ pub fn sign_outputs(
             } else {
                 path
             };
-            signatures.push(sign::sign_file(config, path)?);
+
+            let (sig_file, sig) = sign::sign_file(config, path)?;
+
+            // Add signature to package summary
+            if let Some(summary) = &mut package.summary {
+                summary.signature = Some(sig);
+            }
+
+            signatures.push(sig_file);
         }
     }
 
     Ok(signatures)
+}
+
+/// Create a `latest.json` output summarising the built packages
+pub fn summarise_outputs(
+    config: &Config,
+    packages: &mut Vec<PackageOutput>,
+) -> crate::Result<PathBuf> {
+    #[derive(Debug, Clone, Serialize)]
+    struct InnerRemoteRelease {
+        version: String,
+        notes: Option<String>,
+        pub_date: Option<String>,
+        platforms: Option<HashMap<String, PackageOutputSummary>>,
+    }
+
+    //Collect releases
+    let mut platforms = HashMap::with_capacity(packages.len());
+
+    for package in packages {
+        if let Some(summary) = package.summary.clone() {
+            if summary.signature.is_some() {
+                platforms.insert(summary.platform.clone(), summary);
+            } else {
+                // The signer failed to update the signature field
+                tracing::warn!("A package could not be summarized in latest.json because it could not be signed.")
+            }
+        }
+    }
+
+    // Write latest.json
+    let release = InnerRemoteRelease {
+        version: config.version.clone(),
+        notes: None,
+        pub_date: Some(
+            time::OffsetDateTime::now_utc()
+                .format(&time::format_description::well_known::Rfc3339)
+                .unwrap(),
+        ),
+        platforms: Some(platforms),
+    };
+
+    //Write it to the file
+    let summary_path = config.out_dir().join("latest.json");
+    let summary_file = File::create(summary_path.clone())?;
+
+    serde_json::to_writer_pretty(summary_file, &release)?;
+
+    tracing::info!("Finished summarising at:\n{}", summary_path.display());
+
+    Ok(summary_path)
 }
 
 /// Package an app using the specified config.

--- a/crates/packager/src/package/mod.rs
+++ b/crates/packager/src/package/mod.rs
@@ -351,7 +351,7 @@ fn build_package_summary(
                     })
                 }
                 _ => {
-                    tracing::warn!("A package could not be summarized in latest.json because the platform string could not be determined from {target_triple}.");
+                    tracing::warn!(target_triple =?config.target_triple(), ?target_arch, ?target_os, "A package could not be summarized in latest.json because the platform string could not be determined from {target_triple}.");
                     None
                 }
             }

--- a/crates/packager/src/package/mod.rs
+++ b/crates/packager/src/package/mod.rs
@@ -125,10 +125,14 @@ pub fn package(config: &Config) -> crate::Result<Vec<PackageOutput>> {
             format.short_name(),
         )?;
 
+        let mut produce_summary: bool = true;
+
         let paths = match format {
             PackageFormat::App => app::package(&ctx),
             #[cfg(target_os = "macos")]
             PackageFormat::Dmg => {
+                produce_summary = false;
+
                 // PackageFormat::App is required for the DMG bundle
                 if !packages
                     .iter()
@@ -177,7 +181,10 @@ pub fn package(config: &Config) -> crate::Result<Vec<PackageOutput>> {
             }
         }?;
 
-        let summary = build_package_summary(&paths, format, config)?;
+        let summary = produce_summary
+            .then(|| build_package_summary(&paths, format, config))
+            .transpose()?
+            .flatten();
 
         packages.push(PackageOutput {
             format,

--- a/crates/packager/src/package/mod.rs
+++ b/crates/packager/src/package/mod.rs
@@ -125,6 +125,7 @@ pub fn package(config: &Config) -> crate::Result<Vec<PackageOutput>> {
             format.short_name(),
         )?;
 
+        #[allow(unused_mut)]
         let mut produce_summary: bool = true;
 
         let paths = match format {

--- a/crates/updater/src/custom_serialization.rs
+++ b/crates/updater/src/custom_serialization.rs
@@ -112,3 +112,17 @@ impl<'de> Deserialize<'de> for RemoteRelease {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::RemoteRelease;
+
+    #[test]
+    fn test() {
+        let res = serde_json::from_str(include_str!("../tests/latest.json")).unwrap();
+        let out = serde_json::from_value::<RemoteRelease>(res);
+
+        dbg!(&out);
+        out.expect("failed to deserialize");
+    }
+}

--- a/crates/updater/src/custom_serialization.rs
+++ b/crates/updater/src/custom_serialization.rs
@@ -20,6 +20,21 @@ where
     Version::from_str(str.trim_start_matches('v')).map_err(Error::custom)
 }
 
+/// Deserialize UpdateFormat such that an unrecognised update format
+/// returns an Ok(None) rather than erroring out the whole process.
+pub fn parse_update_format<'de, D>(deserializer: D) -> Result<Option<UpdateFormat>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let update_format = UpdateFormat::deserialize(deserializer);
+
+    if let Err(err) = &update_format {
+        log::warn!("Unknown updater format: {:?}", err);
+    }
+
+    Ok(update_format.ok())
+}
+
 impl<'de> Deserialize<'de> for UpdateFormat {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
@@ -87,9 +102,11 @@ impl<'de> Deserialize<'de> for RemoteRelease {
                     signature: release.signature.ok_or_else(|| {
                         Error::custom("the `signature` field was not set on the updater response")
                     })?,
-                    format: release.format.ok_or_else(|| {
+                    // We don't want a partial ReleaseManifestPlatform for a Dynamic updater response,
+                    // even though the type says we could
+                    format: Some(release.format.ok_or_else(|| {
                         Error::custom("the `format` field was not set on the updater response")
-                    })?,
+                    })?),
                 })
             },
         })

--- a/crates/updater/src/lib.rs
+++ b/crates/updater/src/lib.rs
@@ -150,7 +150,7 @@ use reqwest::{
     StatusCode,
 };
 use semver::Version;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::{
     collections::HashMap,
     io::{Cursor, Read},
@@ -170,7 +170,7 @@ pub use semver;
 pub use url;
 
 /// Install modes for the Windows update.
-#[derive(Debug, PartialEq, Eq, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Default, Deserialize)]
 pub enum WindowsUpdateInstallMode {
     /// Specifies there's a basic UI during the installation process, including a final dialog box at the end.
     BasicUi,
@@ -203,7 +203,7 @@ impl WindowsUpdateInstallMode {
 }
 
 /// The updater configuration for Windows.
-#[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WindowsConfig {
     /// Additional arguments given to the NSIS or WiX installer.
@@ -213,7 +213,7 @@ pub struct WindowsConfig {
 }
 
 /// Updater configuration.
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Config {
     /// The updater endpoints.
@@ -232,7 +232,7 @@ pub struct Config {
 }
 
 /// Supported update format
-#[derive(Debug, Serialize, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum UpdateFormat {
     /// The NSIS installer (.exe).
     Nsis,
@@ -260,7 +260,7 @@ impl std::fmt::Display for UpdateFormat {
 }
 
 /// Information about a release
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct ReleaseManifestPlatform {
     /// Download URL for the platform
     pub url: Url,
@@ -272,7 +272,7 @@ pub struct ReleaseManifestPlatform {
 }
 
 /// Information about a release data.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum RemoteReleaseData {
     /// Dynamic release data based on the platform the update has been requested from.

--- a/crates/updater/src/lib.rs
+++ b/crates/updater/src/lib.rs
@@ -267,7 +267,8 @@ pub struct ReleaseManifestPlatform {
     /// Signature for the platform
     pub signature: String,
     /// Update format
-    pub format: UpdateFormat,
+    #[serde(deserialize_with = "custom_serialization::parse_update_format")]
+    pub format: Option<UpdateFormat>,
 }
 
 /// Information about a release data.
@@ -326,12 +327,13 @@ impl RemoteRelease {
     /// The release's update format for the given target.
     pub fn format(&self, target: &str) -> Result<UpdateFormat> {
         match self.data {
-            RemoteReleaseData::Dynamic(ref platform) => Ok(platform.format),
+            RemoteReleaseData::Dynamic(ref platform) => platform
+                .format
+                .ok_or(Error::TargetNotFound(target.to_string())),
             RemoteReleaseData::Static { ref platforms } => platforms
                 .get(target)
-                .map_or(Err(Error::TargetNotFound(target.to_string())), |platform| {
-                    Ok(platform.format)
-                }),
+                .and_then(|platform| platform.format)
+                .ok_or(Error::TargetNotFound(target.to_string())),
         }
     }
 }

--- a/crates/updater/src/lib.rs
+++ b/crates/updater/src/lib.rs
@@ -583,7 +583,8 @@ impl Updater {
                         }
                     } else {
                         log::error!(
-                            "update endpoint did not respond with a successful status code"
+                            "update endpoint did not respond with a successful status code ({})",
+                            res.status()
                         );
                     }
                 }

--- a/crates/updater/tests/latest.json
+++ b/crates/updater/tests/latest.json
@@ -1,0 +1,27 @@
+{
+  "version": "5.6.1",
+  "notes": null,
+  "pub_date": "2026-05-01T10:55:06.0489829Z",
+  "platforms": {
+    "windows-x86_64": {
+      "url": "https://github.com/UniFlyApp/UniFlyV5/releases/download/v5.6.1/unifly_5.6.1_x64-setup.exe",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUK2NFaGg4dm1UN0lkSS9WbFJFYVBpcU1Sa05uRnBMTUxvYi9tSkpZRzNQSmk0L2NBN0hPMlZRUFhkSVpWcjFMa1dlVGhhQ0VGVWtGTnBDaXJrRXFLdVlEVGRodzhGNUFjPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzc3NjMyOTA2CWZpbGU6dW5pZmx5XzUuNi4xX3g2NC1zZXR1cC5leGUKb0RvaS8vd3FCeFduR1hDbFRsaCt1Rk5xQlF3YjBqY1NobnNxZ1djeWNoOFl0UUIrMFhWaC9vK2Q0S2FKWkQvajFta1p0SGJpdy9VS3VyOWcyNlFZQmc9PQo=",
+      "format": "nsis"
+    },
+    "macos-aarch64": {
+      "url": "https://github.com/UniFlyApp/UniFlyV5/releases/download/v5.6.1/UniFly.app",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUK2NFaGg4dm1UN01KUVV4UGZiN1k2cENyU05nY1VkNkZPaW5QME5XWW5GTWpzVUlWTE9jQjV4M0s3eE1wZW14VGw5ZkJLemoxNXN2YWM2Y3c5MmFieWhydURwSTVFN0F3PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzc3NjMyNDc4CWZpbGU6VW5pRmx5LmFwcC50YXIuZ3oKVktWWmxkQ3RIbW5qbTB5N0xjQzhpQmt3NlBjVXNOS0NvYWYrTm5UQTl4U29naDJzVjBCSC92MXEyTnhKM2xkZTVNaEltbkF1cmxYcDFRN3R6TDBMQWc9PQo=",
+      "format": "app"
+    },
+    "linux-x86_64": {
+      "url": "https://github.com/UniFlyApp/UniFlyV5/releases/download/v/unifly__x86_64.tar.gz",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUK2NFaGg4dm1UN0d1VG1zQk9wQW1abnJnTmtRVnpIVGh2elEvMmEyNWNldWhJSm1WcDA0ekxQK09mODJvajlUY2RCcmx4Q0daL2lIbFliSTdVY3dMUXF2L3c3ZS9LSWdZPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzc3NjMyNzUyCWZpbGU6dW5pZmx5X194ODZfNjQudGFyLmd6Cm12UHpLUUtiREI4Q3NIZjlsVWVDbEdNMldlLy90eDExWFRXdXlDU1RUT29LWndxT2liVmpSRUp2dXk2VmhhZ1VRcjRSd2RhK0FOR0VhSXRNZVRPVUN3PT0K",
+      "format": "pacman"
+    },
+    "windows-i686": {
+      "url": "https://github.com/UniFlyApp/UniFlyV5/releases/download/v5.6.1/unifly_5.6.1_x86-setup.exe",
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVUK2NFaGg4dm1UN0pqZFBhSjhPTSsrUzBvRmdHalhmeUtKcHVzeDBJR1Q1RDRMSjlPMXU1b3ZQMzdqdlg0ZjF6bjljZlV3aDFhNDh4cTJVaHc5RU5XMkZBOVMyTVhMTUFRPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzc3NjMzMDc3CWZpbGU6dW5pZmx5XzUuNi4xX3g4Ni1zZXR1cC5leGUKb0FzcVcxRU5lbXpjanJ6LzBFNE85aFVaQ1dmZmtMRWZZL3BVUCtIZkp6Q3FCM2s1V2JQQXoyR3VpaDdJZGNEQjRSaEFyTkhqTmpQZk8xdThrY1U4QVE9PQo=",
+      "format": "nsis"
+    }
+  }
+}


### PR DESCRIPTION
(Duplicate of [#351](https://github.com/crabnebula-dev/cargo-packager/pull/351) in order to get git commits signed properly)

This PR will have cargo-packager automatically build a `latest.json` artefact which summarises all of the other artefacts to be consumed as an updater endpoint. This makes using cargo-packager through Github actions and Github releases fully automated by allowing the updater endpoint to be a statically hosted `latest.json` file accessible through `https://github.com/org/repo/releases/latest/download/latest.json`. This closes https://github.com/crabnebula-dev/cargo-packager/issues/350

# Changes to Packager config
```rust
  /// When set, a summary `latest.json` build artefact will be generated which can be
  /// hosted alongside other build artefacts as an endpoint for the updater, including
  /// meta data about the version and URL's to point at each of the other build artefacts.
  ///
  /// Specifically, this URL specifies where these build artefacts are hosted. For example,
  /// a using Github Releases: `https://github.com/org/repo/releases/download/v{{version}}/{{artefact}}`
  ///
  /// Each endpoint optionally could have `{{version}}` or `{{artefact}}`
  /// which will be detected and replaced with the appropriate value
  ///
  /// - `{{version}}`: The version of the app which is being packaged
  /// - `{{artefact}}`: The file name of the particular build artefact
  ///     One URL is produced per build artefact.
  pub endpoint: Option<Url>,
```

# Example `latest.json`
Here is an example of a latest.json generated by this PR. The schema is compatible with the existing Updater crate.
```json
{
  "version": "4.0.0",
  "notes": null,
  "pub_date": "2025-07-04T14:12:24.096236Z",
  "platforms": {
    "aarch64-apple-darwin": {
      "url": "https://github.com/org/repo/org/download/v4.0.0/app_4.0.0_aarch64.dmg",
      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIGNhcmdvLXBhY2thZ2VyIHNlY3JldCBrZXkKUlVSRC82M0RjS29jcTNETVJGblAybzRtTmJlTUVZQjlBcXJPUzlUSHVDYWtSYlVTc3FzeUdBd0VWVDFEdXFrdnBqek9WT3ZrV01XcmtrZk1NYlVJNGpHSm5OTWFyRmJDRUFJPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzUxNjM4MzQ0CWZpbGU6VW5pRmx5XzQuMC4wX2FhcmNoNjQuZG1nCnR3aXFqZFMzOHIxbGJOcCtKK3QxMzVreEg1VUFvUE5qa1FsTUxHalMzNWd6NzNabkV3cGJGOWZNQ29aSXVmemZVamorRmppSG9Fa3RXSytUVkNvb0J3PT0K",
      "format": "dmg"
    }
  }
}
```


# Caveats
1. I have not implemented any of this for the NodeJS part of the updater, but I expect that should be fairly do-able
2. When a particular packager format produces multiple build artefacts I have not included any logic to determine which build artefact the `latest.json` should point to, so currently those packager formats are excluded from the `latest.json`. 
3. This assumes the updates are hosted at a single (github) endpoint, whilst the updater has support for fetching from potentially multiple endpoints. I think this is passable because I assume Github releases already has its own redundancy.