### PR TITLE
Fix updater's macos target name in README and docs

### DIFF
--- a/bindings/updater/nodejs/README.md
+++ b/bindings/updater/nodejs/README.md
@@ -88,12 +88,12 @@ Here is an example of the two expected JSON formats:
     "notes": "Test version",
     "pub_date": "2020-06-22T19:25:57Z",
     "platforms": {
-      "darwin-x86_64": {
+      "macos-x86_64": {
         "signature": "Content of app.tar.gz.sig",
         "url": "https://github.com/username/reponame/releases/download/v1.0.0/app-x86_64.app.tar.gz",
         "format": "app"
       },
-      "darwin-aarch64": {
+      "macos-aarch64": {
         "signature": "Content of app.tar.gz.sig",
         "url": "https://github.com/username/reponame/releases/download/v1.0.0/app-aarch64.app.tar.gz",
         "format": "app"

--- a/crates/updater/README.md
+++ b/crates/updater/README.md
@@ -81,12 +81,12 @@ Here is an example of the two expected JSON formats:
     "notes": "Test version",
     "pub_date": "2020-06-22T19:25:57Z",
     "platforms": {
-      "darwin-x86_64": {
+      "macos-x86_64": {
         "signature": "Content of app.tar.gz.sig",
         "url": "https://github.com/username/reponame/releases/download/v1.0.0/app-x86_64.app.tar.gz",
         "format": "app"
       },
-      "darwin-aarch64": {
+      "macos-aarch64": {
         "signature": "Content of app.tar.gz.sig",
         "url": "https://github.com/username/reponame/releases/download/v1.0.0/app-aarch64.app.tar.gz",
         "format": "app"

--- a/crates/updater/src/lib.rs
+++ b/crates/updater/src/lib.rs
@@ -88,12 +88,12 @@
 //!      "notes": "Test version",
 //!      "pub_date": "2020-06-22T19:25:57Z",
 //!      "platforms": {
-//!        "darwin-x86_64": {
+//!        "macos-x86_64": {
 //!          "signature": "Content of app.tar.gz.sig",
 //!          "url": "https://github.com/username/reponame/releases/download/v1.0.0/app-x86_64.app.tar.gz",
 //!          "format": "app"
 //!        },
-//!        "darwin-aarch64": {
+//!        "macos-aarch64": {
 //!          "signature": "Content of app.tar.gz.sig",
 //!          "url": "https://github.com/username/reponame/releases/download/v1.0.0/app-aarch64.app.tar.gz",
 //!          "format": "app"


### PR DESCRIPTION
This is a simple docs change to match up the fact that cargo packager checks "macos-aarch64" rather than "darwin-aarach64" like tauri does in the version json.