### PR TITLE
Use powershell on windows instead of cmd so that cargo.exe packager works from within WSL directories

### DIFF
--- a/crates/packager/src/util.rs
+++ b/crates/packager/src/util.rs
@@ -20,9 +20,9 @@ use crate::{shell::CommandExt, Error};
 #[inline]
 pub(crate) fn cross_command(script: &str) -> Command {
     #[cfg(windows)]
-    let mut cmd = Command::new("cmd");
+    let mut cmd = Command::new("powershell");
     #[cfg(windows)]
-    cmd.arg("/S").arg("/C").arg(script);
+    cmd.arg("-Command").arg(script);
     #[cfg(not(windows))]
     let mut cmd = Command::new("sh");
     cmd.current_dir(dunce::canonicalize(std::env::current_dir().unwrap()).unwrap());


### PR DESCRIPTION
Running `cargo.exe packager` within a WSL directory would previously give me this error:
```
 INFO Running beforePackageCommand `cargo build`
'\\wsl.localhost\Debian\home\fede\projects\terminal_momentum'
CMD.EXE se inici´┐¢ con esta ruta como el directorio actual. No se permiten
rutas UNC. Regresando de manera predeterminada al directorio Windows.
error: could not find `Cargo.toml` in `C:\Windows` or any parent directory
ERROR beforePackagingCommand `cargo build` failed: failed to run command: "cmd" "/S" "/C" "cargo build"
stdout:
stderr: '\\wsl.localhost\Debian\home\fede\projects\terminal_momentum'
CMD.EXE se inici´┐¢ con esta ruta como el directorio actual. No se permiten
rutas UNC. Regresando de manera predeterminada al directorio Windows.
\x1b[1m\x1b[91merror\x1b[0m: could not find `Cargo.toml` in `C:\Windows` or any parent directory
```
This error which translated means that cmd.exe will default to `C:\Windows` if within a WSL directory, which obviously screws up the compilation step.