### PR TITLE
feat(updater): require authenticated signed metadata, ref #433

### DIFF
--- a/.changes/updater-signed-metadata.md
+++ b/.changes/updater-signed-metadata.md
@@ -1,0 +1,10 @@
+---
+"cargo-packager": minor
+"cargo-packager-updater": minor
+---
+
+Cryptographically bind update metadata to the signed artifact to defeat downgrade, freeze and replay attacks. `cargo-packager` now embeds the release `version` (and a `timestamp`) into the (authenticated) minisign trusted comment when signing packages, and the updater verifies that the version advertised by the (unsigned) manifest matches the signed one before installing.
+
+The updater now **always requires** this authenticated metadata: updates whose signatures do not carry a signed `version` and `timestamp` are rejected. **Action required:** update the `cargo-packager` CLI in your release pipeline so your artifacts are signed with this metadata — packages signed by an older `cargo-packager` (or a third-party minisign signer) will be refused by updated clients.
+
+New signer entry points `sign_file_with_version`, `sign_file_with_secret_key_and_version` and `sign_outputs_with_version` produce the version binding (the existing functions still work and now embed the version when invoked through the packaging pipeline). The optional `UpdaterBuilder::signature_expiration` additionally rejects updates whose authenticated signing timestamp is older than a given age.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -1036,6 +1036,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serial_test",
  "tar",
  "tempfile",
  "thiserror 2.0.18",
@@ -2384,7 +2385,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2819,7 +2820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5431,7 +5432,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6078,7 +6079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6770,7 +6771,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7294,7 +7295,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7712,6 +7713,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08a72d8216842fdd57820dc78d840bef99248e35fb2554ff923319e60f2d686b"
 dependencies = [
  "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -8673,7 +8699,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10153,7 +10179,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/bindings/updater/nodejs/index.d.ts
+++ b/bindings/updater/nodejs/index.d.ts
@@ -35,6 +35,8 @@ export interface Options {
   headers?: Record<string, string>
   /** Request timeout in milliseconds. */
   timeout?: number
+  /** Reject updates whose authenticated signing timestamp is older than this many milliseconds. */
+  signatureExpiration?: number
 }
 /** Supported update format */
 export const enum UpdateFormat {

--- a/bindings/updater/nodejs/src/lib.rs
+++ b/bindings/updater/nodejs/src/lib.rs
@@ -51,6 +51,8 @@ pub struct Options {
     pub headers: Option<HashMap<String, String>>,
     /// Request timeout in milliseconds.
     pub timeout: Option<u32>,
+    /// Reject updates whose authenticated signing timestamp is older than this many milliseconds.
+    pub signature_expiration: Option<u32>,
 }
 
 impl Options {
@@ -59,6 +61,7 @@ impl Options {
         let executable_path = self.executable_path.take();
         let headers = self.headers.take();
         let timeout = self.timeout.take();
+        let signature_expiration = self.signature_expiration.take();
         let config: cargo_packager_updater::Config = self.into();
 
         let mut builder = UpdaterBuilder::new(current_version, config);
@@ -70,6 +73,10 @@ impl Options {
         }
         if let Some(timeout) = timeout {
             builder = builder.timeout(Duration::from_millis(timeout as u64));
+        }
+        if let Some(signature_expiration) = signature_expiration {
+            builder =
+                builder.signature_expiration(Duration::from_millis(signature_expiration as u64));
         }
         if let Some(headers) = headers {
             for (key, value) in headers {
@@ -175,6 +182,7 @@ impl Update {
                 map
             },
             format: self.format.into(),
+            signature_expiration: None,
         })
     }
 }

--- a/crates/packager/src/cli/mod.rs
+++ b/crates/packager/src/cli/mod.rs
@@ -10,7 +10,8 @@ use clap::{ArgAction, CommandFactory, FromArgMatches, Parser, Subcommand};
 
 use crate::{
     config::{LogLevel, PackageFormat},
-    init_tracing_subscriber, package, parse_log_level, sign_outputs, util, SigningConfig,
+    init_tracing_subscriber, package, parse_log_level, sign_outputs_with_version, util,
+    SigningConfig,
 };
 
 mod config;
@@ -178,7 +179,7 @@ fn run_cli(cli: Cli) -> Result<()> {
 
         // sign the packages
         if let Some(signing_config) = &signing_config {
-            let s = sign_outputs(signing_config, &mut packages)?;
+            let s = sign_outputs_with_version(signing_config, &mut packages, Some(&config.version))?;
             signatures.extend(s);
         }
 

--- a/crates/packager/src/cli/mod.rs
+++ b/crates/packager/src/cli/mod.rs
@@ -179,7 +179,8 @@ fn run_cli(cli: Cli) -> Result<()> {
 
         // sign the packages
         if let Some(signing_config) = &signing_config {
-            let s = sign_outputs_with_version(signing_config, &mut packages, Some(&config.version))?;
+            let s =
+                sign_outputs_with_version(signing_config, &mut packages, Some(&config.version))?;
             signatures.extend(s);
         }
 

--- a/crates/packager/src/lib.rs
+++ b/crates/packager/src/lib.rs
@@ -259,6 +259,7 @@ pub fn package_and_sign(
     signing_config: &SigningConfig,
 ) -> crate::Result<(Vec<PackageOutput>, Vec<PathBuf>)> {
     let mut packages = package(config)?;
-    let signatures = sign_outputs_with_version(signing_config, &mut packages, Some(&config.version))?;
+    let signatures =
+        sign_outputs_with_version(signing_config, &mut packages, Some(&config.version))?;
     Ok((packages, signatures))
 }

--- a/crates/packager/src/lib.rs
+++ b/crates/packager/src/lib.rs
@@ -209,6 +209,21 @@ pub fn sign_outputs(
     config: &SigningConfig,
     packages: &mut Vec<PackageOutput>,
 ) -> crate::Result<Vec<PathBuf>> {
+    sign_outputs_with_version(config, packages, None)
+}
+
+/// Sign the specified packages and return the signatures paths, embedding an authenticated
+/// `version` into each signature's trusted comment.
+///
+/// Binding the version to the signed artifact lets the updater reject manifests that advertise a
+/// mismatched version, defeating downgrade attacks. Passing `None` keeps the legacy signature
+/// format. See [`sign::sign_file_with_version`].
+#[tracing::instrument(level = "trace")]
+pub fn sign_outputs_with_version(
+    config: &SigningConfig,
+    packages: &mut Vec<PackageOutput>,
+    version: Option<&str>,
+) -> crate::Result<Vec<PathBuf>> {
     let mut signatures = Vec::new();
     for package in packages {
         for path in &package.paths.clone() {
@@ -225,7 +240,7 @@ pub fn sign_outputs(
             } else {
                 path
             };
-            signatures.push(sign::sign_file(config, path)?);
+            signatures.push(sign::sign_file_with_version(config, path, version)?);
         }
     }
 
@@ -244,6 +259,6 @@ pub fn package_and_sign(
     signing_config: &SigningConfig,
 ) -> crate::Result<(Vec<PackageOutput>, Vec<PathBuf>)> {
     let mut packages = package(config)?;
-    let signatures = sign_outputs(signing_config, &mut packages)?;
+    let signatures = sign_outputs_with_version(signing_config, &mut packages, Some(&config.version))?;
     Ok((packages, signatures))
 }

--- a/crates/packager/src/sign.rs
+++ b/crates/packager/src/sign.rs
@@ -145,8 +145,23 @@ pub fn sign_file<P: AsRef<Path> + Debug>(
     config: &SigningConfig,
     path: P,
 ) -> crate::Result<PathBuf> {
+    sign_file_with_version(config, path, None)
+}
+
+/// Signs a specified file using the specified signing configuration, embedding an authenticated
+/// `version` into the signature's trusted comment.
+///
+/// The version is cryptographically bound to the artifact (minisign signs the trusted comment), so
+/// the updater can reject manifests that advertise a version which does not match the signed one,
+/// defeating downgrade attacks. Passing `None` produces a signature compatible with older releases.
+#[tracing::instrument(level = "trace")]
+pub fn sign_file_with_version<P: AsRef<Path> + Debug>(
+    config: &SigningConfig,
+    path: P,
+    version: Option<&str>,
+) -> crate::Result<PathBuf> {
     let secret_key = decode_private_key(&config.private_key, config.password.as_deref())?;
-    sign_file_with_secret_key(&secret_key, path)
+    sign_file_with_secret_key_and_version(&secret_key, path, version)
 }
 
 /// Signs a specified file using an already decoded secret key.
@@ -155,6 +170,17 @@ pub fn sign_file_with_secret_key<P: AsRef<Path> + Debug>(
     secret_key: &minisign::SecretKey,
     path: P,
 ) -> crate::Result<PathBuf> {
+    sign_file_with_secret_key_and_version(secret_key, path, None)
+}
+
+/// Signs a specified file using an already decoded secret key, embedding an authenticated `version`
+/// into the signature's trusted comment. See [`sign_file_with_version`].
+#[tracing::instrument(level = "trace")]
+pub fn sign_file_with_secret_key_and_version<P: AsRef<Path> + Debug>(
+    secret_key: &minisign::SecretKey,
+    path: P,
+    version: Option<&str>,
+) -> crate::Result<PathBuf> {
     let path = path.as_ref();
     let signature_path = path.with_additional_extension("sig");
     let signature_path = dunce::simplified(&signature_path);
@@ -162,13 +188,21 @@ pub fn sign_file_with_secret_key<P: AsRef<Path> + Debug>(
     let mut signature_box_writer = util::create_file(signature_path)?;
     let start = SystemTime::now();
     let since_epoch = start.duration_since(UNIX_EPOCH)?.as_secs();
-    let trusted_comment = format!(
+    let mut trusted_comment = format!(
         "timestamp:{}\tfile:{}",
         since_epoch,
         path.file_name()
             .ok_or_else(|| crate::Error::FailedToExtractFilename(path.to_path_buf()))?
             .to_string_lossy()
     );
+    // Bind the release version into the (authenticated) trusted comment when known. Tabs separate
+    // fields and the version is the last one so the format stays forwards/backwards compatible.
+    if let Some(version) = version {
+        let version = version.trim();
+        if !version.is_empty() {
+            trusted_comment.push_str(&format!("\tversion:{version}"));
+        }
+    }
 
     let file = OpenOptions::new()
         .read(true)

--- a/crates/updater/Cargo.toml
+++ b/crates/updater/Cargo.toml
@@ -45,3 +45,4 @@ flate2 = "1.0"
 
 [dev-dependencies]
 tiny_http = "0.12"
+serial_test = "3"

--- a/crates/updater/src/error.rs
+++ b/crates/updater/src/error.rs
@@ -57,6 +57,25 @@ pub enum Error {
     /// Temp dir is not on same mount mount. This prevents our updater to rename the AppImage to a temp file.
     #[error("temp directory is not on the same mount point as the AppImage")]
     TempDirNotOnSameMountPoint,
+    /// The authenticated version embedded in the update signature does not match the advertised version.
+    #[error("update metadata mismatch: the signed version `{signed}` does not match the advertised version `{advertised}`. The update may have been tampered with.")]
+    SignedVersionMismatch {
+        /// The version authenticated by the signature's trusted comment.
+        signed: String,
+        /// The version advertised in the (unsigned) update manifest.
+        advertised: String,
+    },
+    /// The update signature does not contain the authenticated metadata required by the updater.
+    #[error("the update signature does not contain the authenticated metadata (version/timestamp) required by the updater")]
+    MissingSignedMetadata,
+    /// The update signature is older than the configured maximum age.
+    #[error("the update signature is stale: it was signed at unix timestamp {signed_timestamp}, which is older than the configured maximum age of {max_age_secs}s")]
+    StaleSignature {
+        /// The authenticated signing timestamp (seconds since the unix epoch).
+        signed_timestamp: i64,
+        /// The configured maximum signature age, in seconds.
+        max_age_secs: u64,
+    },
     /// The `reqwest` crate errors.
     #[error(transparent)]
     Reqwest(#[from] reqwest::Error),

--- a/crates/updater/src/lib.rs
+++ b/crates/updater/src/lib.rs
@@ -133,6 +133,41 @@
 //! - [`"Passive"`](WindowsUpdateInstallMode::Passive): There will be a small window with a progress bar. The update will be installed without requiring any user interaction. Generally recommended and the default mode.
 //! - [`"BasicUi"`](WindowsUpdateInstallMode::BasicUi): There will be a basic user interface shown which requires user interaction to finish the installation.
 //! - [`"Quiet"`](WindowsUpdateInstallMode::Quiet): There will be no progress feedback to the user. With this mode the installer cannot request admin privileges by itself so it only works in user-wide installations or when your app itself already runs with admin privileges. Generally not recommended.
+//!
+//! ## Update authenticity and anti-rollback
+//!
+//! Every update artefact is verified against the configured [`Config::pubkey`] before installation.
+//! The updater also **requires** that the signature carries authenticated metadata — a `version` and
+//! `timestamp` embedded in the minisign trusted comment — and checks that the version advertised by
+//! the (unsigned) manifest matches the signed version, so a compromised distribution channel cannot
+//! advertise a high version number while serving an older, validly-signed artefact. Updates whose
+//! signatures lack this metadata are rejected.
+//!
+//! Every artefact signed by an up-to-date `cargo-packager` carries this metadata, so make sure the
+//! `cargo-packager` CLI in your release pipeline is current. Artefacts signed without it (a
+//! third-party minisign signer, or an old `cargo-packager`) cannot be installed.
+//!
+//! [`signature_expiration`](UpdaterBuilder::signature_expiration) additionally rejects updates whose
+//! authenticated signing timestamp is too old (guarding against freeze/replay attacks).
+//!
+//! ## Rotating the signing key
+//!
+//! The trust anchor is the [`Config::pubkey`] compiled into your application. Because that public
+//! key travels inside the application binary, rotating it is just another update:
+//!
+//! 1. Generate a new key pair.
+//! 2. Build a new release that embeds the **new** public key in its updater [`Config`].
+//! 3. Sign that release with your **old** private key.
+//!
+//! Clients still running the previous version verify the new release with the old public key they
+//! already trust, install it, and from then on trust the new key — so subsequent releases must be
+//! signed with the new private key. Keep the old private key available until enough of your fleet has
+//! migrated.
+//!
+//! This planned-rotation flow does not, by itself, recover from a *compromised* private key (an
+//! attacker holding the old key could also sign a malicious release). Recovering from key compromise
+//! requires an out-of-band channel, e.g. shipping a fresh installer through your normal distribution
+//! site.
 
 #![deny(missing_docs)]
 
@@ -345,6 +380,7 @@ pub struct UpdaterBuilder {
     target: Option<String>,
     headers: HeaderMap,
     timeout: Option<Duration>,
+    signature_expiration: Option<Duration>,
 }
 
 impl UpdaterBuilder {
@@ -358,6 +394,7 @@ impl UpdaterBuilder {
             target: None,
             headers: Default::default(),
             timeout: None,
+            signature_expiration: None,
         }
     }
 
@@ -413,6 +450,16 @@ impl UpdaterBuilder {
     /// Specify a timeout for the updater request.
     pub fn timeout(mut self, timeout: Duration) -> Self {
         self.timeout = Some(timeout);
+        self
+    }
+
+    /// Reject updates whose authenticated signing timestamp is older than `max_age`.
+    ///
+    /// This uses the cryptographically signed `timestamp` from the signature's trusted comment
+    /// (not the unsigned `pub_date` manifest field), providing protection against freeze and replay
+    /// attacks that try to keep a device on an old, vulnerable version.
+    pub fn signature_expiration(mut self, max_age: Duration) -> Self {
+        self.signature_expiration = Some(max_age);
         self
     }
 
@@ -478,6 +525,7 @@ impl UpdaterBuilder {
             json_target,
             headers: self.headers,
             extract_path,
+            signature_expiration: self.signature_expiration,
         })
     }
 }
@@ -495,6 +543,7 @@ pub struct Updater {
     json_target: String,
     headers: HeaderMap,
     extract_path: PathBuf,
+    signature_expiration: Option<Duration>,
 }
 
 impl Updater {
@@ -622,6 +671,7 @@ impl Updater {
                 timeout: self.timeout,
                 headers: self.headers.clone(),
                 format: release.format(&self.json_target)?,
+                signature_expiration: self.signature_expiration,
             })
         } else {
             None
@@ -658,6 +708,8 @@ pub struct Update {
     pub headers: HeaderMap,
     /// Update format
     pub format: UpdateFormat,
+    /// Maximum allowed age for the update signature, based on its authenticated signing timestamp.
+    pub signature_expiration: Option<Duration>,
 }
 
 impl Update {
@@ -756,9 +808,77 @@ impl Update {
 
         let mut update_buffer = Cursor::new(&buffer);
 
-        verify_signature(&mut update_buffer, &self.signature, &self.config.pubkey)?;
+        let signed_metadata =
+            verify_signature(&mut update_buffer, &self.signature, &self.config.pubkey)?;
+        self.validate_signed_metadata(&signed_metadata)?;
 
         Ok(buffer)
+    }
+
+    /// Enforce the updater's metadata policy against the authenticated metadata extracted from a
+    /// verified signature's trusted comment.
+    ///
+    /// This cryptographically binds the (unsigned) manifest to the signed artifact and protects
+    /// against downgrade, freeze and replay attacks:
+    ///
+    /// - the signature must carry authenticated metadata (a `version` and `timestamp`); updates
+    ///   without it are rejected;
+    /// - the authenticated `version` must match the advertised manifest version, so an attacker
+    ///   cannot advertise a high version number while serving an older, validly-signed artifact;
+    /// - the authenticated signing `timestamp` is checked against [`Update::signature_expiration`]
+    ///   to reject stale signatures.
+    fn validate_signed_metadata(&self, signed: &SignedMetadata) -> Result<()> {
+        // The signature must carry both an authenticated version and timestamp. Every artefact signed
+        // by `cargo-packager` does; updates signed without this metadata (an old `cargo-packager`, a
+        // third-party minisign signer, ...) are rejected. Update the `cargo-packager` CLI in your
+        // release pipeline so the metadata is signed.
+        let (Some(signed_version), Some(signed_timestamp)) = (&signed.version, signed.timestamp)
+        else {
+            log::error!(
+                "rejecting update: signature is missing the authenticated metadata (version/timestamp). Sign the update with an up-to-date cargo-packager."
+            );
+            return Err(Error::MissingSignedMetadata);
+        };
+
+        // Version binding: the version advertised by the (unsigned) manifest must match the
+        // authenticated version, so a compromised channel cannot advertise a high version number
+        // while serving an older, validly-signed artefact.
+        let matches = match (
+            Version::parse(signed_version.trim_start_matches('v')),
+            Version::parse(self.version.trim_start_matches('v')),
+        ) {
+            (Ok(signed_v), Ok(advertised_v)) => signed_v == advertised_v,
+            // Fall back to a normalized string comparison if either side is not valid semver.
+            _ => signed_version.trim_start_matches('v') == self.version.trim_start_matches('v'),
+        };
+        if !matches {
+            log::error!(
+                "rejecting update: signed version `{signed_version}` does not match advertised version `{}`",
+                self.version
+            );
+            return Err(Error::SignedVersionMismatch {
+                signed: signed_version.clone(),
+                advertised: self.version.clone(),
+            });
+        }
+
+        // Freshness: reject signatures older than the configured maximum age, guarding against
+        // freeze and replay attacks.
+        if let Some(max_age) = self.signature_expiration {
+            let now = OffsetDateTime::now_utc().unix_timestamp();
+            if now.saturating_sub(signed_timestamp) > max_age.as_secs() as i64 {
+                log::error!(
+                    "rejecting update: signature signed at {signed_timestamp} is older than the configured maximum age of {}s",
+                    max_age.as_secs()
+                );
+                return Err(Error::StaleSignature {
+                    signed_timestamp,
+                    max_age_secs: max_age.as_secs(),
+                });
+            }
+        }
+
+        Ok(())
     }
 
     /// Installs the updater package downloaded by [`Update::download`]
@@ -1179,16 +1299,46 @@ fn extract_path_from_executable(executable_path: &Path) -> Result<PathBuf> {
     Ok(extract_path)
 }
 
-// Validate signature
-// need to be public because its been used
-// by our tests in the bundler
+/// Authenticated metadata extracted from a verified signature's trusted comment.
+///
+/// minisign signs the trusted comment as part of its global signature, so any field parsed here is
+/// cryptographically authenticated once [`verify_signature`] returns successfully.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SignedMetadata {
+    /// The signing time as a unix timestamp (seconds), if present in the trusted comment.
+    pub timestamp: Option<i64>,
+    /// The authenticated artifact version, if present in the trusted comment.
+    pub version: Option<String>,
+}
+
+/// Parse the (authenticated) trusted comment of a minisign signature.
+///
+/// The trusted comment is a single line of tab-separated `key:value` fields, e.g.
+/// `timestamp:1700000000\tfile:app.tar.gz\tversion:1.2.3`. Unknown fields are ignored so the
+/// format can be extended without breaking older clients.
+fn parse_trusted_comment(comment: &str) -> SignedMetadata {
+    let mut metadata = SignedMetadata::default();
+    for field in comment.split('\t') {
+        if let Some(value) = field.strip_prefix("timestamp:") {
+            metadata.timestamp = value.trim().parse().ok();
+        } else if let Some(value) = field.strip_prefix("version:") {
+            let value = value.trim();
+            if !value.is_empty() {
+                metadata.version = Some(value.to_string());
+            }
+        }
+    }
+    metadata
+}
+
+// Validate signature and return the authenticated metadata from the signature's trusted comment.
 //
 // NOTE: The buffer position is not reset.
 fn verify_signature<R>(
     archive_reader: &mut R,
     release_signature: &str,
     pub_key: &str,
-) -> Result<bool>
+) -> Result<SignedMetadata>
 where
     R: Read,
 {
@@ -1202,9 +1352,9 @@ where
     let mut data = Vec::new();
     archive_reader.read_to_end(&mut data)?;
 
-    // Validate signature or bail out
+    // Validate signature or bail out. This also authenticates the trusted comment.
     public_key.verify(&data, &signature, true)?;
-    Ok(true)
+    Ok(parse_trusted_comment(signature.trusted_comment()))
 }
 
 fn base64_to_string(base64_string: &str) -> Result<String> {
@@ -1213,4 +1363,127 @@ fn base64_to_string(base64_string: &str) -> Result<String> {
         .map_err(|_| Error::SignatureUtf8(base64_string.into()))?
         .to_string();
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn url(s: &str) -> Url {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn parse_trusted_comment_fields() {
+        let meta = parse_trusted_comment("timestamp:1700000000\tfile:app.tar.gz\tversion:1.2.3");
+        assert_eq!(meta.timestamp, Some(1_700_000_000));
+        assert_eq!(meta.version.as_deref(), Some("1.2.3"));
+
+        // legacy comment without a version
+        let legacy = parse_trusted_comment("timestamp:1700000000\tfile:app.tar.gz");
+        assert_eq!(legacy.timestamp, Some(1_700_000_000));
+        assert!(legacy.version.is_none());
+
+        // empty version is treated as absent
+        let empty = parse_trusted_comment("timestamp:1\tfile:app\tversion:");
+        assert!(empty.version.is_none());
+    }
+
+    /// Build a minimal [`Update`] for exercising the metadata validation policy.
+    fn update_for(advertised_version: &str, signature_expiration: Option<Duration>) -> Update {
+        Update {
+            config: Config::default(),
+            body: None,
+            current_version: "0.1.0".into(),
+            version: advertised_version.into(),
+            date: None,
+            target: "linux-x86_64".into(),
+            extract_path: PathBuf::new(),
+            download_url: url("https://example.com/app.tar.gz"),
+            signature: String::new(),
+            timeout: None,
+            headers: HeaderMap::new(),
+            format: UpdateFormat::AppImage,
+            signature_expiration,
+        }
+    }
+
+    #[test]
+    fn signed_version_binding() {
+        let update = update_for("1.2.3", None);
+
+        // matching version (with and without leading `v`) passes
+        assert!(update
+            .validate_signed_metadata(&SignedMetadata {
+                timestamp: Some(1),
+                version: Some("1.2.3".into()),
+            })
+            .is_ok());
+        assert!(update
+            .validate_signed_metadata(&SignedMetadata {
+                timestamp: Some(1),
+                version: Some("v1.2.3".into()),
+            })
+            .is_ok());
+
+        // a mismatching signed version (e.g. old artifact served under a faked high version) fails
+        let err = update
+            .validate_signed_metadata(&SignedMetadata {
+                timestamp: Some(1),
+                version: Some("1.0.0".into()),
+            })
+            .unwrap_err();
+        assert!(matches!(err, Error::SignedVersionMismatch { .. }));
+    }
+
+    #[test]
+    fn missing_metadata_always_rejected() {
+        let update = update_for("1.2.3", None);
+
+        // no authenticated metadata at all
+        let err = update
+            .validate_signed_metadata(&SignedMetadata::default())
+            .unwrap_err();
+        assert!(matches!(err, Error::MissingSignedMetadata));
+
+        // version present but no timestamp
+        let err = update
+            .validate_signed_metadata(&SignedMetadata {
+                timestamp: None,
+                version: Some("1.2.3".into()),
+            })
+            .unwrap_err();
+        assert!(matches!(err, Error::MissingSignedMetadata));
+
+        // timestamp present but no version
+        let err = update
+            .validate_signed_metadata(&SignedMetadata {
+                timestamp: Some(1),
+                version: None,
+            })
+            .unwrap_err();
+        assert!(matches!(err, Error::MissingSignedMetadata));
+    }
+
+    #[test]
+    fn signature_expiration_enforced() {
+        let now = OffsetDateTime::now_utc().unix_timestamp();
+
+        // a signature within the max age passes
+        assert!(update_for("1.2.3", Some(Duration::from_secs(3600)))
+            .validate_signed_metadata(&SignedMetadata {
+                timestamp: Some(now - 60),
+                version: Some("1.2.3".into()),
+            })
+            .is_ok());
+
+        // a stale signature is rejected
+        let err = update_for("1.2.3", Some(Duration::from_secs(3600)))
+            .validate_signed_metadata(&SignedMetadata {
+                timestamp: Some(now - 7200),
+                version: Some("1.2.3".into()),
+            })
+            .unwrap_err();
+        assert!(matches!(err, Error::StaleSignature { .. }));
+    }
 }

--- a/crates/updater/tests/update.rs
+++ b/crates/updater/tests/update.rs
@@ -15,6 +15,7 @@ use std::{
 use serde::Serialize;
 
 const UPDATER_PRIVATE_KEY: &str = include_str!("./dummy.key");
+const UPDATER_PUBLIC_KEY: &str = include_str!("./dummy.pub.key");
 
 #[derive(Serialize)]
 struct PlatformUpdate {
@@ -89,6 +90,7 @@ impl UpdaterFormat {
     }
 }
 
+#[serial_test::serial]
 #[test]
 #[ignore]
 fn update_app() {
@@ -319,4 +321,113 @@ fn update_app() {
             .current_dir(&manifest_dir)
             .output();
     }
+}
+
+// Ensures the version-binding check rejects an update whose (unsigned) manifest advertises a
+// version that does not match the authenticated version embedded in the artifact's signature.
+//
+// We build & sign a real `1.0.0` artifact (whose signature's trusted comment embeds `version:1.0.0`)
+// but serve a manifest that advertises `2.0.0` while pointing at that same `1.0.0` artifact. The
+// signature itself is valid for the bytes, so verification passes, but `download()` must then reject
+// the update with `Error::SignedVersionMismatch` because the signed version (`1.0.0`) differs from
+// the advertised version (`2.0.0`). This is exactly the downgrade vector the version binding defends
+// against (advertise a high version while serving an older, validly-signed artifact).
+#[serial_test::serial]
+#[test]
+#[ignore]
+fn rejects_metadata_version_mismatch() {
+    let target =
+        cargo_packager_updater::target().expect("running updater test in an unsupported platform");
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let root_dir = manifest_dir.join("../..").canonicalize().unwrap();
+
+    // build & sign a real 1.0.0 artifact; its signature embeds `version:1.0.0` in the trusted comment
+    let format = UpdaterFormat::default()[0];
+    build_app(&manifest_dir, &root_dir, "1.0.0", &[format]);
+
+    #[cfg(target_os = "linux")]
+    let update_package_path =
+        root_dir.join("target/debug/cargo-packager-updater-app-test_1.0.0_x86_64.AppImage");
+    #[cfg(target_os = "macos")]
+    let update_package_path = root_dir.join("target/debug/CargoPackagerAppUpdaterTest.app.tar.gz");
+    #[cfg(windows)]
+    let update_package_path =
+        root_dir.join("target/debug/cargo-packager-updater-app-test_1.0.0_x64-setup.exe");
+
+    let ext = update_package_path.extension().unwrap().to_str().unwrap();
+    let signature_path = update_package_path.with_extension(format!("{ext}.sig"));
+    let signature = fs::read_to_string(&signature_path)
+        .unwrap_or_else(|_| panic!("failed to read signature file {}", signature_path.display()));
+
+    // bind the listening port before spawning the server thread so the client can't race it
+    let server = tiny_http::Server::http("localhost:3008").expect("failed to start updater server");
+    let update_package = update_package_path.clone();
+    let served_target = target.clone();
+    std::thread::spawn(move || loop {
+        let Ok(request) = server.recv() else {
+            continue;
+        };
+        match request.url() {
+            "/" => {
+                let mut platforms = HashMap::new();
+                platforms.insert(
+                    served_target.clone(),
+                    PlatformUpdate {
+                        signature: signature.clone(),
+                        url: "http://localhost:3008/download",
+                        format: format.name(),
+                    },
+                );
+                // advertise 2.0.0 while serving the 1.0.0 artifact -> version mismatch
+                let body = serde_json::to_vec(&Update {
+                    version: "2.0.0",
+                    date: time::OffsetDateTime::now_utc()
+                        .format(&time::format_description::well_known::Rfc3339)
+                        .unwrap(),
+                    platforms,
+                })
+                .unwrap();
+                let len = body.len();
+                let response = tiny_http::Response::new(
+                    tiny_http::StatusCode(200),
+                    Vec::new(),
+                    std::io::Cursor::new(body),
+                    Some(len),
+                    None,
+                );
+                let _ = request.respond(response);
+            }
+            "/download" => {
+                let _ = request.respond(tiny_http::Response::from_file(
+                    File::open(&update_package).unwrap_or_else(|_| {
+                        panic!("failed to open package {}", update_package.display())
+                    }),
+                ));
+                return;
+            }
+            _ => (),
+        }
+    });
+
+    let config = cargo_packager_updater::Config {
+        endpoints: vec!["http://localhost:3008".parse().unwrap()],
+        pubkey: UPDATER_PUBLIC_KEY.into(),
+        ..Default::default()
+    };
+
+    // current version 1.0.0 < advertised 2.0.0, so an update is offered
+    let update = cargo_packager_updater::check_update("1.0.0".parse().unwrap(), config)
+        .expect("failed to check for update")
+        .expect("expected the server to advertise an update");
+    assert_eq!(update.version, "2.0.0");
+
+    // the signature is valid for the bytes, but the signed version (1.0.0) != advertised (2.0.0)
+    let err = update
+        .download()
+        .expect_err("download must fail because the signed version does not match the manifest");
+    assert!(
+        matches!(err, cargo_packager_updater::Error::SignedVersionMismatch { .. }),
+        "expected SignedVersionMismatch, got: {err:?}"
+    );
 }

--- a/crates/updater/tests/update.rs
+++ b/crates/updater/tests/update.rs
@@ -427,7 +427,10 @@ fn rejects_metadata_version_mismatch() {
         .download()
         .expect_err("download must fail because the signed version does not match the manifest");
     assert!(
-        matches!(err, cargo_packager_updater::Error::SignedVersionMismatch { .. }),
+        matches!(
+            err,
+            cargo_packager_updater::Error::SignedVersionMismatch { .. }
+        ),
         "expected SignedVersionMismatch, got: {err:?}"
     );
 }


### PR DESCRIPTION
Embed the release version (and timestamp) into the signed minisign trusted comment when packaging, and require the updater to verify that the manifest's advertised version matches the signed one. Updates whose signatures lack this authenticated metadata are rejected, defeating downgrade/freeze/replay attacks. Adds `signature_expiration` to reject stale signatures, and version-aware signer entry points. Update the cargo-packager CLI in your release pipeline so the metadata is signed.